### PR TITLE
Link against the exact python3 version in the system

### DIFF
--- a/host/py_module/CMakeLists.txt
+++ b/host/py_module/CMakeLists.txt
@@ -27,7 +27,18 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 include(${dldt_dir}/inference-engine/thirdparty/movidius/XLink/XLink.cmake)
 
 
-find_package(PythonLibs 3 REQUIRED)
+execute_process(
+    COMMAND python3 -c "v = __import__('sys').version_info; \
+                        print(v.major, v.minor, sep = '.', end = ''); \
+                       "
+    OUTPUT_VARIABLE PYTHON_VERSION
+    RESULT_VARIABLE PYTHON_ERROR
+)
+if(PYTHON_ERROR)
+    message(FATAL_ERROR "python3 get version error: " ${PYTHON_ERROR})
+endif(PYTHON_ERROR)
+
+find_package(PythonLibs   ${PYTHON_VERSION} EXACT REQUIRED)
 # set(PYTHON_EXECUTABLE "/usr/bin/python3.6-dbg")
 # set(PYTHON_EXECUTABLE "/usr/bin/python")
 

--- a/host/py_module/CMakeLists.txt
+++ b/host/py_module/CMakeLists.txt
@@ -39,6 +39,7 @@ if(PYTHON_ERROR)
 endif(PYTHON_ERROR)
 
 find_package(PythonLibs   ${PYTHON_VERSION} EXACT REQUIRED)
+find_package(PythonInterp ${PYTHON_VERSION} EXACT REQUIRED)
 # set(PYTHON_EXECUTABLE "/usr/bin/python3.6-dbg")
 # set(PYTHON_EXECUTABLE "/usr/bin/python")
 


### PR DESCRIPTION
With multiple `python3` versions installed (side by side, or within Conda environments), 
CMake's `find_package` always returned the latest (e.g. even if we specify 3.6, if 3.7 is found, it is used instead).
With an older python3 interpreter enabled as default, this was causing a wrong lib to be built, not the one expected by the selected python3 interpreter.

However, `find_package` has an option `EXACT` that would solve the above issue, but we don't want to hardcode a specific version.
We query the version from the python3 interpreter and pass it to `find_package`.
