### PR TITLE
12mp rgb mode

### DIFF
--- a/host/core/pipeline/host_pipeline_config.cpp
+++ b/host/core/pipeline/host_pipeline_config.cpp
@@ -6,7 +6,8 @@
 static std::unordered_map<int, int> rgb_cam_supported_configs =
 {
     {1080, 0},
-    {2160, 1}
+    {2160, 1},
+    {3040, 2}
 };
 
 static std::unordered_map<int, int> mono_cam_supported_configs =


### PR DESCRIPTION
Adding 12 mp rgb mode.
Both encoding and jpeg are cropped to 3840*2160.