### PR TITLE
Fix Macos segfault at quit

### DIFF
--- a/host/core/host_capture_command.cpp
+++ b/host/core/host_capture_command.cpp
@@ -18,6 +18,15 @@ void HostCaptureCommand::sendDisparityConfidenceThreshold(uint8_t confidence_thr
     notifyObservers(stream, conf_thr_metadata);
 }
 
+void HostCaptureCommand::sendCustomDeviceResetRequest(void){
+    StreamData custom_reset;
+    uint32_t reset = 0xDEADDEAD;
+    custom_reset.packet_number = 0;
+    custom_reset.data = &reset;
+    custom_reset.size = sizeof(reset);
+    notifyObservers(stream, custom_reset);
+}
+
 void HostCaptureCommand::capture(){
     sendCaptureMetadata(CaptureMetadata::createStillCapture());
 }

--- a/host/core/host_capture_command.hpp
+++ b/host/core/host_capture_command.hpp
@@ -14,6 +14,7 @@ public:
     void afMode(CaptureMetadata::AutofocusMode mode);
     void afTrigger();
     void sendDisparityConfidenceThreshold(uint8_t confidence_thr);
+    void sendCustomDeviceResetRequest(void);
 
 private:
     StreamInfo stream;

--- a/host/py_module/py_bindings.cpp
+++ b/host/py_module/py_bindings.cpp
@@ -304,6 +304,8 @@ bool init_device(
 
 bool soft_deinit_device()
 {
+    if(g_host_caputure_command != nullptr)
+        g_host_caputure_command->sendCustomDeviceResetRequest();
     g_xlink = nullptr;
     g_disparity_post_proc = nullptr;
     g_device_support_listener = nullptr;
@@ -314,11 +316,8 @@ bool soft_deinit_device()
 bool deinit_device()
 {
     wdog_stop();       
-    g_xlink = nullptr;
-    g_disparity_post_proc = nullptr;
-    g_device_support_listener = nullptr;
-    g_host_caputure_command = nullptr;
-	gl_result = nullptr;
+    soft_deinit_device();
+    gl_result = nullptr;
     return true;
 }
 


### PR DESCRIPTION
Fix Macos segfault at quit by implementing custom device reset command. Before deinitializing resources we send a reset command to device to perform a harakiri. Normally Xlink does this, but there is a BUG w/ Xlink reset on MacOS, so we use ours. (And it's better to use ours anyways, so we don't rely on Xlink)