### PR TITLE
Rename depth_raw to depth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "depthai-core"]
 	path = depthai-core
-	url = https://github.com/luxonis/depthai-core.git
+	url = ../depthai-core.git


### PR DESCRIPTION
Stream depth_raw has been renamed to depth to match naming convention with other streams.

Git submodule path was changed to relative to inherit root repo's SSH/HTTPS url.

`git submodule sync --recursive` 
is suggested.