### PR TITLE
Gen1 updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,10 @@ target_link_libraries(${TARGET_NAME}
 
 # Add bindings revision
 target_compile_definitions(${TARGET_NAME} PRIVATE DEPTHAI_PYTHON_BINDINGS_REVISION="${PROJECT_VERSION}")
-# Add commit hash
+# Add commit hash, default to "dev"
+if(NOT DEPTHAI_PYTHON_COMMIT_HASH)
+    set(DEPTHAI_PYTHON_COMMIT_HASH dev)
+endif()
 if(DEPTHAI_PYTHON_COMMIT_HASH)
     target_compile_definitions(${TARGET_NAME} PRIVATE DEPTHAI_PYTHON_COMMIT_HASH="${DEPTHAI_PYTHON_COMMIT_HASH}")
 endif()


### PR DESCRIPTION
Set a default value for CMake variable `DEPTHAI_PYTHON_COMMIT_HASH`: `"dev"`, will be used to skip version check in depthai demo python scripts for local/development builds.
This will suffice for simple builds (like `cmake ..`), but not with `setup.py`

Related PR: https://github.com/luxonis/depthai-core/pull/16