### PR TITLE
Release 0.4.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 # Pybindings project
 set(TARGET_NAME depthai)
-project(${TARGET_NAME} VERSION "0") # revision of bindings [depthai-core].[rev]
+project(${TARGET_NAME} VERSION "1") # revision of bindings [depthai-core].[rev]
 
 # Add depthai-cpp dependency
 add_subdirectory(depthai-core EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Tag will be created after merged.

Release includes:
Fix for model downloader when there is space in path.
Moved open3d install as optional.
Added -fusb2 for calibration.
Switched to 400p stereo resolution by default.
Added orientation check in calibration.
Flip camera orientation for OAK-1 by default.
Removed deprecated CLI options.
Increased manual exposure limits.