### PR TITLE
Checkout submodules in Github Action

### DIFF
--- a/.github/workflows/docker-hub-g2-devel.yml
+++ b/.github/workflows/docker-hub-g2-devel.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,7 +12,6 @@ RUN pip install opencv-python
 COPY . /depthai-python
 RUN mkdir -p depthai-python/build
 RUN cd /depthai-python && \
-    git submodule update --init --recursive && \
     cd build && \
     cmake .. && \
     make -j


### PR DESCRIPTION
The Docker image build was failing because the `.git` directory was not copied into the container.