### PR TITLE
Add new example and add missing example descriptions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,7 @@ Now, pick a tutorial or code sample and start utilizing Gen2 capabilities
    samples/15_rgb_mobilenet_4k.rst
    samples/16_device_queue_event.rst
    samples/17_video_mobilenet.rst
+   samples/18_rgb_encoding_mobilenet.rst
 
 
 .. toctree::

--- a/docs/source/samples/01_rgb_preview.rst
+++ b/docs/source/samples/01_rgb_preview.rst
@@ -1,6 +1,10 @@
 01 - RGB Preview
 ================
 
+This example shows how to set up a pipeline that outpus a small preview of the RGB camera,
+connects over XLink to transfer these to the host real-time, and displays the RGB frames
+on the host with OpenCV.
+
 Demo
 ####
 

--- a/docs/source/samples/02_mono_preview.rst
+++ b/docs/source/samples/02_mono_preview.rst
@@ -1,6 +1,9 @@
 02 - Mono Preview
 =================
 
+This example shows how to set up a pipeline that outputs the left and right grayscale camera
+images, connects over XLink to transfer these to the host real-time, and displays both using OpenCV.
+
 Demo
 ####
 

--- a/docs/source/samples/03_depth_preview.rst
+++ b/docs/source/samples/03_depth_preview.rst
@@ -1,6 +1,10 @@
 03 - Depth Preview
 ==================
 
+This example shows how to set the SGBM (semi-global-matching) disparity-depth node, connects
+over XLink to transfer the results to the host real-time, and displays the depth map in OpenCV.
+Note that disparity is used in this case, as it colorizes in a more intuitive way.
+
 Demo
 ####
 

--- a/docs/source/samples/04_rgb_encoding.rst
+++ b/docs/source/samples/04_rgb_encoding.rst
@@ -1,6 +1,18 @@
 04 - RGB Encoding
 =================
 
+This example shows how to configure the depthai video encoder in h.265 format to encode the RGB camera
+input at 8MP/4K/2160p (3840x2160) at 30FPS (the maximum possible encoding resolultion possible for the
+encoder, higher frame-rates are possible at lower resolutions, like 1440p at 60FPS), and transfers the
+encoded video over XLINK to the host, saving it to disk as a video file.
+
+Pressing Ctrl+C will stop the recording and then convert it using ffmpeg into an mp4 to make it
+playable. Note that ffmpeg will need to be installed and runnable for the conversion to mp4 to succeed.
+
+Be careful, this example saves encoded video to your host storage. So if you leave them running,
+you could fill up your storage on your host.
+
+
 Demo
 ####
 

--- a/docs/source/samples/05_rgb_mono_encoding.rst
+++ b/docs/source/samples/05_rgb_mono_encoding.rst
@@ -1,6 +1,16 @@
 05 - RGB & Mono Encoding
 ========================
 
+This example shows how to set up the encoder node to encode the RGB camera and both grayscale cameras
+(of DepthAI/OAK-D) at the same time. The RGB is set to 1920x1080 and the grayscale are set to 1280x720
+each, all at 30FPS. Each encoded video stream is transferred over XLINK and saved to a respective file.
+
+Pressing Ctrl+C will stop the recording and then convert it using ffmpeg into an mp4 to make it
+playable. Note that ffmpeg will need to be installed and runnable for the conversion to mp4 to succeed.
+
+Be careful, this example saves encoded video to your host storage. So if you leave them running,
+you could fill up your storage on your host.
+
 Demo
 ####
 

--- a/docs/source/samples/06_rgb_full_resolution_saver.rst
+++ b/docs/source/samples/06_rgb_full_resolution_saver.rst
@@ -1,6 +1,15 @@
 06 - RGB Full Resolution Saver
 ==============================
 
+This example does its best to save full-resolution 3840x2160 .png files as fast at it can from the
+RGB sensor. It serves as an example of recording high resolution to disk for the purposes of
+high-resolution ground-truth data. We also recently added the options to save isp - YUV420p
+uncompressed frames, processed by ISP, and raw - BayerRG (R_Gr_Gb_B), as read from sensor,
+10-bit packed. See here for the pull request on this capability.
+
+Be careful, this example saves full resolution .png pictures to your host storage. So if you leave
+them running, you could fill up your storage on your host.
+
 Demo
 ####
 

--- a/docs/source/samples/07_mono_full_resolution_saver.rst
+++ b/docs/source/samples/07_mono_full_resolution_saver.rst
@@ -1,6 +1,9 @@
 07 - Mono Full Resolution Saver
 ===============================
 
+This example shows how to save 1280x720p .png of the right grayscale camera to disk. Left is defined
+as from the boards perspective.
+
 Demo
 ####
 

--- a/docs/source/samples/08_rgb_mobilenet.rst
+++ b/docs/source/samples/08_rgb_mobilenet.rst
@@ -1,6 +1,9 @@
 08 - RGB & MobilenetSSD
 =======================
 
+This example shows how to MobileNetv2SSD on the RGB input frame, and how to display both the RGB
+preview and the metadata results from the MobileNetv2SSD on the preview.
+
 Demo
 ####
 

--- a/docs/source/samples/09_mono_mobilenet.rst
+++ b/docs/source/samples/09_mono_mobilenet.rst
@@ -1,6 +1,9 @@
 09 - Mono & MobilenetSSD
 ========================
 
+This example shows how to run MobileNetv2SSD on the left grayscale camera and how to display the
+neural network results on a preview of the right camera stream.
+
 Demo
 ####
 

--- a/docs/source/samples/10_mono_depth_mobilenetssd.rst
+++ b/docs/source/samples/10_mono_depth_mobilenetssd.rst
@@ -1,6 +1,10 @@
 10 - Mono & MobilenetSSD & Encoding
 ===================================
 
+This example shows how to run MobileNetv2SSD on the left grayscale camera in parallel with running
+the disparity depth results, displaying both the depth map and the right grayscale stream, with the
+bounding box from the neural network overlaid.
+
 Demo
 ####
 

--- a/docs/source/samples/11_rgb_encoding_mono_mobilenet.rst
+++ b/docs/source/samples/11_rgb_encoding_mono_mobilenet.rst
@@ -1,6 +1,17 @@
 11 - RGB & Encoding & Mono & MobilenetSSD
 =========================================
 
+This example shows how to configure the depthai video encoder in h.265 format to encode the RGB camera
+input at Full-HD resolution at 30FPS, and transfers the encoded video over XLINK to the host,
+saving it to disk as a video file. In the same time, a MobileNetv2SSD network is ran on the
+frames from right grayscale camera
+
+Pressing Ctrl+C will stop the recording and then convert it using ffmpeg into an mp4 to make it
+playable. Note that ffmpeg will need to be installed and runnable for the conversion to mp4 to succeed.
+
+Be careful, this example saves encoded video to your host storage. So if you leave them running,
+you could fill up your storage on your host.
+
 Demo
 ####
 

--- a/docs/source/samples/12_rgb_encoding_mono_mobilenet_depth.rst
+++ b/docs/source/samples/12_rgb_encoding_mono_mobilenet_depth.rst
@@ -1,6 +1,19 @@
 12 - RGB Encoding & Mono with MobilenetSSD & Depth
 ================================================
 
+This example shows how to configure the depthai video encoder in h.265 format to encode the RGB camera
+input at Full-HD resolution at 30FPS, and transfers the encoded video over XLINK to the host,
+saving it to disk as a video file. In the same time, a MobileNetv2SSD network is ran on the
+frames from right grayscale camera, while the application also displays the depth map produced by both
+of the grayscale cameras. Note that disparity is used in this case, as it colorizes in a more
+intuitive way.
+
+Pressing Ctrl+C will stop the recording and then convert it using ffmpeg into an mp4 to make it
+playable. Note that ffmpeg will need to be installed and runnable for the conversion to mp4 to succeed.
+
+Be careful, this example saves encoded video to your host storage. So if you leave them running,
+you could fill up your storage on your host.
+
 Demo
 ####
 

--- a/docs/source/samples/14_color_camera_control.rst
+++ b/docs/source/samples/14_color_camera_control.rst
@@ -1,6 +1,15 @@
 14 - Color Camera Control
 =========================
 
+This example shows how to controll the device-side crop and camera triggers.
+An output is a displayed RGB cropped frame, that can be manipulated using the following keys:
+
+#. `a` will move the crop left
+#. `d` will move the crop right
+#. `w` will move the crop up
+#. `s` will move the crop down
+#. `c` will trigger a `still` event, causing the current frame to be captured and sent over `still` output from camera node
+
 Demo
 ####
 

--- a/docs/source/samples/15_rgb_mobilenet_4k.rst
+++ b/docs/source/samples/15_rgb_mobilenet_4k.rst
@@ -1,6 +1,10 @@
 15 - 4K RGB MobileNetSSD
 ========================
 
+This example shows how to MobileNetv2SSD on the RGB input frame, and how to display both the RGB
+preview and the metadata results from the MobileNetv2SSD on the preview.
+The preview size is set to 4K resolution
+
 Demo
 ####
 

--- a/docs/source/samples/16_device_queue_event.rst
+++ b/docs/source/samples/16_device_queue_event.rst
@@ -1,6 +1,9 @@
 16 - Device Queue Event
 =======================
 
+This example shows how to use :code:`getQueueEvent` function in order to be notified when one of
+the packets from selected streams arrive
+
 Demo
 ####
 

--- a/docs/source/samples/17_video_mobilenet.rst
+++ b/docs/source/samples/17_video_mobilenet.rst
@@ -1,6 +1,11 @@
 17 - Video & MobilenetSSD
 =========================
 
+This example shows how to MobileNetv2SSD on the RGB input frame, which is read from the specified file,
+and not from the RGB camera, and how to display both the RGB
+frame and the metadata results from the MobileNetv2SSD on the frame.
+DepthAI is used here only as a processing unit
+
 Demo
 ####
 

--- a/docs/source/samples/18_rgb_encoding_mobilenet.rst
+++ b/docs/source/samples/18_rgb_encoding_mobilenet.rst
@@ -1,10 +1,10 @@
-13 - Encoding Max Limit
-=====================
+18 - RGB Encoding with MobilenetSSD
+===================================
 
-This example shows how to set up the encoder node to encode the RGB camera and both grayscale cameras
-(of DepthAI/OAK-D) at the same time, having all encoder parameters set to maximum quality and FPS.
-The RGB is set to 4K (3840x2160) and the grayscale are set to 1280x720 each, all at 30FPS.
-Each encoded video stream is transferred over XLINK and saved to a respective file.
+This example shows how to configure the depthai video encoder in h.265 format to encode the RGB camera
+input at Full-HD resolution at 30FPS, and transfers the encoded video over XLINK to the host,
+saving it to disk as a video file. In the same time, a MobileNetv2SSD network is ran on the
+frames from the same RGB camera that is used for encoding
 
 Pressing Ctrl+C will stop the recording and then convert it using ffmpeg into an mp4 to make it
 playable. Note that ffmpeg will need to be installed and runnable for the conversion to mp4 to succeed.
@@ -18,7 +18,7 @@ Demo
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-        <iframe src="https://www.youtube.com/embed/myqmcSFq-i0" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+        <iframe src="https://www.youtube.com/embed/tE_glawKIho" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
     </div>
 
 Setup
@@ -32,12 +32,15 @@ Please run the following command to install the required dependencies
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
 
+This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to work - you can download it from
+`here <https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet.blob>`__
+
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/13_encoding_max_limit.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/18_rgb_encoding_mobilenet.py>`__
 
-.. literalinclude:: ../../../examples/13_encoding_max_limit.py
+.. literalinclude:: ../../../examples/18_rgb_encoding_mobilenet.py
    :language: python
    :linenos:
 

--- a/examples/18_rgb_encoding_mobilenet.py
+++ b/examples/18_rgb_encoding_mobilenet.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import sys
+import cv2
+import depthai as dai
+import numpy as np
+
+# Get argument first
+mobilenet_path = str((Path(__file__).parent / Path('models/mobilenet.blob')).resolve().absolute())
+if len(sys.argv) > 1:
+    mobilenet_path = sys.argv[1]
+
+
+pipeline = dai.Pipeline()
+
+cam = pipeline.createColorCamera()
+cam.setBoardSocket(dai.CameraBoardSocket.RGB)
+cam.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
+cam.setPreviewSize(300, 300)
+cam.setInterleaved(False)
+
+videoEncoder = pipeline.createVideoEncoder()
+videoEncoder.setDefaultProfilePreset(1920, 1080, 30, dai.VideoEncoderProperties.Profile.H265_MAIN)
+cam.video.link(videoEncoder.input)
+
+detection_nn = pipeline.createNeuralNetwork()
+detection_nn.setBlobPath(mobilenet_path)
+cam.preview.link(detection_nn.input)
+
+videoOut = pipeline.createXLinkOut()
+videoOut.setStreamName('h265')
+videoEncoder.bitstream.link(videoOut.input)
+
+xout_rgb = pipeline.createXLinkOut()
+xout_rgb.setStreamName("rgb")
+cam.preview.link(xout_rgb.input)
+
+xout_nn = pipeline.createXLinkOut()
+xout_nn.setStreamName("nn")
+detection_nn.out.link(xout_nn.input)
+
+device = dai.Device(pipeline)
+device.startPipeline()
+
+queue_size = 8
+q_rgb = device.getOutputQueue("rgb", queue_size)
+q_nn = device.getOutputQueue("nn", queue_size)
+q_rgb_enc = device.getOutputQueue('h265', maxSize=30, blocking=True)
+
+frame = None
+bboxes = []
+
+
+def frame_norm(frame, bbox):
+    return (np.array(bbox) * np.array([*frame.shape[:2], *frame.shape[:2]])[::-1]).astype(int)
+
+
+videoFile = open('video.h265','wb')
+
+while True:
+    in_rgb = q_rgb.tryGet()
+    in_nn = q_nn.tryGet()
+
+    while q_rgb_enc.has():
+        q_rgb_enc.get().getData().tofile(videoFile)
+
+
+    if in_rgb is not None:
+        # if the data from the rgb camera is available, transform the 1D data into a HxWxC frame
+        shape = (3, in_rgb.getHeight(), in_rgb.getWidth())
+        frame = in_rgb.getData().reshape(shape).transpose(1, 2, 0).astype(np.uint8)
+        frame = np.ascontiguousarray(frame)
+
+    if in_nn is not None:
+        bboxes = np.array(in_nn.getFirstLayerFp16())
+        bboxes = bboxes[:np.where(bboxes == -1)[0][0]]
+        bboxes = bboxes.reshape((bboxes.size // 7, 7))
+        bboxes = bboxes[bboxes[:, 2] > 0.5][:, 3:7]
+
+    if frame is not None:
+        for raw_bbox in bboxes:
+            bbox = frame_norm(frame, raw_bbox)
+            cv2.rectangle(frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
+        cv2.imshow("rgb", frame)
+
+    if cv2.waitKey(1) == ord('q'):
+        break
+
+videoFile.close()
+
+print("To view the encoded data, convert the stream file (.h265) into a video file (.mp4) using a command below:")
+print("ffmpeg -framerate 30 -i video.h265 -c copy video.mp4")


### PR DESCRIPTION
Added missing descriptions for examples and also RGB encoding + nn inference example

[![Iexample video](https://img.youtube.com/vi/tE_glawKIho/0.jpg)](https://www.youtube.com/watch?v=tE_glawKIho)