### PR TITLE
Update mobilenet labels

### DIFF
--- a/examples/08_rgb_mobilenet.py
+++ b/examples/08_rgb_mobilenet.py
@@ -33,6 +33,10 @@ xout_nn = pipeline.createXLinkOut()
 xout_nn.setStreamName("nn")
 detection_nn.out.link(xout_nn.input)
 
+# MobilenetSSD label texts
+texts = ["background", "aeroplane", "bicycle", "bird", "boat", "bottle", "bus", "car", "cat", "chair", "cow",
+         "diningtable", "dog", "horse", "motorbike", "person", "pottedplant", "sheep", "sofa", "train", "tvmonitor"]
+
 
 # Pipeline defined, now the device is connected to
 with dai.Device(pipeline) as device:
@@ -45,6 +49,7 @@ with dai.Device(pipeline) as device:
 
     frame = None
     bboxes = []
+    labels = []
 
     # nn data, being the bounding box locations, are in <0..1> range - they need to be normalized with frame width/height
     def frame_norm(frame, bbox):
@@ -65,18 +70,20 @@ with dai.Device(pipeline) as device:
         if in_nn is not None:
             # one detection has 7 numbers, and the last detection is followed by -1 digit, which later is filled with 0
             bboxes = np.array(in_nn.getFirstLayerFp16())
-            # take only the results before -1 digit
-            bboxes = bboxes[:np.where(bboxes == -1)[0][0]]
             # transform the 1D array into Nx7 matrix
             bboxes = bboxes.reshape((bboxes.size // 7, 7))
             # filter out the results which confidence less than a defined threshold
-            bboxes = bboxes[bboxes[:, 2] > 0.5][:, 3:7]
+            bboxes = bboxes[bboxes[:, 2] > 0.5]
+            # Cut bboxes and labels
+            labels = bboxes[:, 1].astype(int)
+            bboxes = bboxes[:, 3:7]
 
         if frame is not None:
             # if the frame is available, draw bounding boxes on it and show the frame
-            for raw_bbox in bboxes:
+            for raw_bbox, label in zip(bboxes, labels):
                 bbox = frame_norm(frame, raw_bbox)
                 cv2.rectangle(frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
+                cv2.putText(frame, texts[label], (bbox[0] + 10, bbox[1] + 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, 255)
             cv2.imshow("rgb", frame)
 
         if cv2.waitKey(1) == ord('q'):

--- a/examples/10_mono_depth_mobilenetssd.py
+++ b/examples/10_mono_depth_mobilenetssd.py
@@ -57,6 +57,10 @@ xout_nn = pipeline.createXLinkOut()
 xout_nn.setStreamName("nn")
 detection_nn.out.link(xout_nn.input)
 
+# MobilenetSSD label texts
+texts = ["background", "aeroplane", "bicycle", "bird", "boat", "bottle", "bus", "car", "cat", "chair", "cow",
+         "diningtable", "dog", "horse", "motorbike", "person", "pottedplant", "sheep", "sofa", "train", "tvmonitor"]
+
 # Pipeline defined, now the device is connected to
 with dai.Device(pipeline) as device:
     # Start pipeline
@@ -70,6 +74,7 @@ with dai.Device(pipeline) as device:
     frame_right = None
     frame_depth = None
     bboxes = []
+    labels = []
 
 
     # nn data, being the bounding box locations, are in <0..1> range - they need to be normalized with frame width/height
@@ -97,7 +102,10 @@ with dai.Device(pipeline) as device:
             # transform the 1D array into Nx7 matrix
             bboxes = bboxes.reshape((bboxes.size // 7, 7))
             # filter out the results which confidence less than a defined threshold
-            bboxes = bboxes[bboxes[:, 2] > 0.5][:, 3:7]
+            bboxes = bboxes[bboxes[:, 2] > 0.5]
+            # Cut bboxes and labels
+            labels = bboxes[:, 1].astype(int)
+            bboxes = bboxes[:, 3:7]
 
         if in_depth is not None:
             # data is originally represented as a flat 1D array, it needs to be converted into HxW form
@@ -108,12 +116,17 @@ with dai.Device(pipeline) as device:
 
         if frame_right is not None:
             # if the frame is available, draw bounding boxes on it and show the frame
-            for raw_bbox in bboxes:
+            for raw_bbox, label in zip(bboxes, labels):
                 bbox = frame_norm(frame_right, raw_bbox)
                 cv2.rectangle(frame_right, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
+                cv2.putText(frame_right, texts[label], (bbox[0] + 10, bbox[1] + 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, 255)
             cv2.imshow("right", frame_right)
 
         if frame_depth is not None:
+            for raw_bbox, label in zip(bboxes, labels):
+                bbox = frame_norm(frame_depth, raw_bbox)
+                cv2.rectangle(frame_depth, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (0, 0, 255), 2)
+                cv2.putText(frame_depth, texts[label], (bbox[0] + 10, bbox[1] + 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, (0, 0, 255))
             cv2.imshow("depth", frame_depth)
 
         if cv2.waitKey(1) == ord('q'):

--- a/examples/15_rgb_mobilenet_4k.py
+++ b/examples/15_rgb_mobilenet_4k.py
@@ -39,6 +39,10 @@ xout_nn = pipeline.createXLinkOut()
 xout_nn.setStreamName("nn")
 detection_nn.out.link(xout_nn.input)
 
+# MobilenetSSD label texts
+texts = ["background", "aeroplane", "bicycle", "bird", "boat", "bottle", "bus", "car", "cat", "chair", "cow",
+         "diningtable", "dog", "horse", "motorbike", "person", "pottedplant", "sheep", "sofa", "train", "tvmonitor"]
+
 # Pipeline defined, now the device is connected to
 with dai.Device(pipeline) as device:
     # Start pipeline
@@ -52,6 +56,7 @@ with dai.Device(pipeline) as device:
     preview_frame = None
     video_frame = None
     bboxes = []
+    labels = []
 
 
     # nn data, being the bounding box locations, are in <0..1> range - they need to be normalized with frame width/height
@@ -89,18 +94,27 @@ with dai.Device(pipeline) as device:
         if in_nn is not None:
             # one detection has 7 numbers, and the last detection is followed by -1 digit, which later is filled with 0
             bboxes = np.array(in_nn.getFirstLayerFp16())
-            # take only the results before -1 digit
-            bboxes = bboxes[:np.where(bboxes == -1)[0][0]]
             # transform the 1D array into Nx7 matrix
             bboxes = bboxes.reshape((bboxes.size // 7, 7))
             # filter out the results which confidence less than a defined threshold
-            bboxes = bboxes[bboxes[:, 2] > 0.5][:, 3:7]
+            bboxes = bboxes[bboxes[:, 2] > 0.5]
+            # Cut bboxes and labels
+            labels = bboxes[:, 1].astype(int)
+            bboxes = bboxes[:, 3:7]
 
         # if the frame is available, draw bounding boxes on it and show the frame
         if video_frame is not None:
+            for raw_bbox, label in zip(bboxes, labels):
+                bbox = frame_norm(video_frame, raw_bbox)
+                cv2.rectangle(video_frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
+                cv2.putText(video_frame, texts[label], (bbox[0] + 10, bbox[1] + 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, 255)
             display_frame("video", video_frame, bboxes)
 
         if preview_frame is not None:
+            for raw_bbox, label in zip(bboxes, labels):
+                bbox = frame_norm(preview_frame, raw_bbox)
+                cv2.rectangle(preview_frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
+                cv2.putText(preview_frame, texts[label], (bbox[0] + 10, bbox[1] + 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, 255)
             display_frame("preview", preview_frame, bboxes)
 
         if cv2.waitKey(1) == ord('q'):

--- a/examples/17_video_mobilenet.py
+++ b/examples/17_video_mobilenet.py
@@ -31,6 +31,10 @@ xout_nn = pipeline.createXLinkOut()
 xout_nn.setStreamName("nn")
 detection_nn.out.link(xout_nn.input)
 
+# MobilenetSSD label texts
+texts = ["background", "aeroplane", "bicycle", "bird", "boat", "bottle", "bus", "car", "cat", "chair", "cow",
+         "diningtable", "dog", "horse", "motorbike", "person", "pottedplant", "sheep", "sofa", "train", "tvmonitor"]
+
 
 # Pipeline defined, now the device is connected to
 with dai.Device(pipeline) as device:
@@ -43,7 +47,7 @@ with dai.Device(pipeline) as device:
 
     frame = None
     bboxes = []
-
+    labels = []
 
     # nn data, being the bounding box locations, are in <0..1> range - they need to be normalized with frame width/height
     def frame_norm(frame, bbox):
@@ -70,18 +74,20 @@ with dai.Device(pipeline) as device:
         if in_nn is not None:
             # one detection has 7 numbers, and the last detection is followed by -1 digit, which later is filled with 0
             bboxes = np.array(in_nn.getFirstLayerFp16())
-            # take only the results before -1 digit
-            bboxes = bboxes[:np.where(bboxes == -1)[0][0]]
             # transform the 1D array into Nx7 matrix
             bboxes = bboxes.reshape((bboxes.size // 7, 7))
             # filter out the results which confidence less than a defined threshold
-            bboxes = bboxes[bboxes[:, 2] > 0.5][:, 3:7]
+            bboxes = bboxes[bboxes[:, 2] > 0.5]
+            # Cut bboxes and labels
+            labels = bboxes[:, 1].astype(int)
+            bboxes = bboxes[:, 3:7]
 
         if frame is not None:
             # if the frame is available, draw bounding boxes on it and show the frame
-            for raw_bbox in bboxes:
+            for raw_bbox, label in zip(bboxes, labels):
                 bbox = frame_norm(frame, raw_bbox)
                 cv2.rectangle(frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
+                cv2.putText(frame, texts[label], (bbox[0] + 10, bbox[1] + 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, 255)
             cv2.imshow("rgb", frame)
 
         if cv2.waitKey(1) == ord('q'):

--- a/examples/18_rgb_encoding_mobilenet.py
+++ b/examples/18_rgb_encoding_mobilenet.py
@@ -40,54 +40,59 @@ xout_nn = pipeline.createXLinkOut()
 xout_nn.setStreamName("nn")
 detection_nn.out.link(xout_nn.input)
 
-device = dai.Device(pipeline)
-device.startPipeline()
+# MobilenetSSD label texts
+texts = ["background", "aeroplane", "bicycle", "bird", "boat", "bottle", "bus", "car", "cat", "chair", "cow",
+         "diningtable", "dog", "horse", "motorbike", "person", "pottedplant", "sheep", "sofa", "train", "tvmonitor"]
 
-queue_size = 8
-q_rgb = device.getOutputQueue("rgb", queue_size)
-q_nn = device.getOutputQueue("nn", queue_size)
-q_rgb_enc = device.getOutputQueue('h265', maxSize=30, blocking=True)
+with dai.Device(pipeline) as device:
+    device.startPipeline()
 
-frame = None
-bboxes = []
+    queue_size = 8
+    q_rgb = device.getOutputQueue("rgb", queue_size)
+    q_nn = device.getOutputQueue("nn", queue_size)
+    q_rgb_enc = device.getOutputQueue('h265', maxSize=30, blocking=True)
 
-
-def frame_norm(frame, bbox):
-    return (np.array(bbox) * np.array([*frame.shape[:2], *frame.shape[:2]])[::-1]).astype(int)
-
-
-videoFile = open('video.h265','wb')
-
-while True:
-    in_rgb = q_rgb.tryGet()
-    in_nn = q_nn.tryGet()
-
-    while q_rgb_enc.has():
-        q_rgb_enc.get().getData().tofile(videoFile)
+    frame = None
+    bboxes = []
+    labels = []
 
 
-    if in_rgb is not None:
-        # if the data from the rgb camera is available, transform the 1D data into a HxWxC frame
-        shape = (3, in_rgb.getHeight(), in_rgb.getWidth())
-        frame = in_rgb.getData().reshape(shape).transpose(1, 2, 0).astype(np.uint8)
-        frame = np.ascontiguousarray(frame)
+    def frame_norm(frame, bbox):
+        return (np.array(bbox) * np.array([*frame.shape[:2], *frame.shape[:2]])[::-1]).astype(int)
 
-    if in_nn is not None:
-        bboxes = np.array(in_nn.getFirstLayerFp16())
-        bboxes = bboxes[:np.where(bboxes == -1)[0][0]]
-        bboxes = bboxes.reshape((bboxes.size // 7, 7))
-        bboxes = bboxes[bboxes[:, 2] > 0.5][:, 3:7]
 
-    if frame is not None:
-        for raw_bbox in bboxes:
-            bbox = frame_norm(frame, raw_bbox)
-            cv2.rectangle(frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
-        cv2.imshow("rgb", frame)
+    with open('video.h265', 'wb') as videoFile:
+        while True:
+            in_rgb = q_rgb.tryGet()
+            in_nn = q_nn.tryGet()
 
-    if cv2.waitKey(1) == ord('q'):
-        break
+            while q_rgb_enc.has():
+                q_rgb_enc.get().getData().tofile(videoFile)
 
-videoFile.close()
+
+            if in_rgb is not None:
+                # if the data from the rgb camera is available, transform the 1D data into a HxWxC frame
+                shape = (3, in_rgb.getHeight(), in_rgb.getWidth())
+                frame = in_rgb.getData().reshape(shape).transpose(1, 2, 0).astype(np.uint8)
+                frame = np.ascontiguousarray(frame)
+
+            if in_nn is not None:
+                bboxes = np.array(in_nn.getFirstLayerFp16())
+                bboxes = bboxes.reshape((bboxes.size // 7, 7))
+                bboxes = bboxes[bboxes[:, 2] > 0.5]
+                # Cut bboxes and labels
+                labels = bboxes[:, 1].astype(int)
+                bboxes = bboxes[:, 3:7]
+
+            if frame is not None:
+                for raw_bbox, label in zip(bboxes, labels):
+                    bbox = frame_norm(frame, raw_bbox)
+                    cv2.rectangle(frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), (255, 0, 0), 2)
+                    cv2.putText(frame, texts[label], (bbox[0] + 10, bbox[1] + 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, 255)
+                cv2.imshow("rgb", frame)
+
+            if cv2.waitKey(1) == ord('q'):
+                break
 
 print("To view the encoded data, convert the stream file (.h265) into a video file (.mp4) using a command below:")
 print("ffmpeg -framerate 30 -i video.h265 -c copy video.mp4")


### PR DESCRIPTION
This PR adds labels to MobilenetSSD detections. Also removes troublesome code (`-1` cut) and the detections are printed on all presented frames, not only rgb preview or manip frames.

Demo below:

https://user-images.githubusercontent.com/5244214/106962305-371a4080-673f-11eb-95db-23033e12b02f.mp4


https://user-images.githubusercontent.com/5244214/106962307-384b6d80-673f-11eb-8d8b-aa5a6ad8d793.mp4

