### PR TITLE
Changing min disparity distance to 0.35m

### DIFF
--- a/examples/03_depth_preview.py
+++ b/examples/03_depth_preview.py
@@ -9,11 +9,11 @@ pipeline = dai.Pipeline()
 
 # Define a source - two mono (grayscale) cameras
 left = pipeline.createMonoCamera()
-left.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+left.setResolution(dai.MonoCameraProperties.SensorResolution.THE_400_P)
 left.setBoardSocket(dai.CameraBoardSocket.LEFT)
 
 right = pipeline.createMonoCamera()
-right.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+right.setResolution(dai.MonoCameraProperties.SensorResolution.THE_400_P)
 right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 
 # Create a node that will produce the depth map (using disparity output as it's easier to visualize depth this way)

--- a/examples/10_mono_depth_mobilenetssd.py
+++ b/examples/10_mono_depth_mobilenetssd.py
@@ -17,11 +17,11 @@ pipeline = dai.Pipeline()
 
 # Define a source - mono (grayscale) cameras
 left = pipeline.createMonoCamera()
-left.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+left.setResolution(dai.MonoCameraProperties.SensorResolution.THE_400_P)
 left.setBoardSocket(dai.CameraBoardSocket.LEFT)
 
 right = pipeline.createMonoCamera()
-right.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+right.setResolution(dai.MonoCameraProperties.SensorResolution.THE_400_P)
 right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 
 # Create a node that will produce the depth map (using disparity output as it's easier to visualize depth this way)

--- a/examples/10_mono_depth_mobilenetssd.py
+++ b/examples/10_mono_depth_mobilenetssd.py
@@ -34,9 +34,9 @@ right.out.link(depth.right)
 
 # Create a node to convert the grayscale frame into the nn-acceptable form
 manip = pipeline.createImageManip()
-manip.setResize(300, 300)
+manip.initialConfig.setResize(300, 300)
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
 depth.rectifiedLeft.link(manip.inputImage)
 
 # Define a neural network that will make predictions based on the source frames

--- a/examples/12_rgb_encoding_mono_mobilenet_depth.py
+++ b/examples/12_rgb_encoding_mono_mobilenet_depth.py
@@ -54,9 +54,9 @@ xout_right.setStreamName("rect_right")
 depth.rectifiedRight.link(xout_right.input)
 
 manip = pipeline.createImageManip()
-manip.setResize(300, 300)
+manip.initialConfig.setResize(300, 300)
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
 depth.rectifiedRight.link(manip.inputImage)
 manip.out.link(detection_nn.input)
 

--- a/examples/12_rgb_encoding_mono_mobilenet_depth.py
+++ b/examples/12_rgb_encoding_mono_mobilenet_depth.py
@@ -27,11 +27,11 @@ videoOut.setStreamName('h265')
 videoEncoder.bitstream.link(videoOut.input)
 
 left = pipeline.createMonoCamera()
-left.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+left.setResolution(dai.MonoCameraProperties.SensorResolution.THE_400_P)
 left.setBoardSocket(dai.CameraBoardSocket.LEFT)
 
 right = pipeline.createMonoCamera()
-right.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+right.setResolution(dai.MonoCameraProperties.SensorResolution.THE_400_P)
 right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 
 depth = pipeline.createStereoDepth()


### PR DESCRIPTION
## Changing the default resolution in Example 10 from 720p to 400p cuts the min distance in half, allowing trying it at the desk.
720p example:
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/64262095/107372903-39392200-6ae6-11eb-82e7-cecf60e56a6f.gif)

400p example:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/64262095/107373268-a056d680-6ae6-11eb-95b8-41e3f775ce24.gif)
