### PR TITLE
Added initial opencv / numpy integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 # Pybindings project
 set(TARGET_NAME depthai)
-project(${TARGET_NAME} VERSION "1") # revision of bindings [depthai-core].[rev]
+project(depthai VERSION "1") # revision of bindings [depthai-core].[rev]
 
 # First specify options
 option(DEPTHAI_PYTHON_ENABLE_TESTS "Enable tests" OFF)
@@ -66,7 +66,7 @@ target_link_libraries(${TARGET_NAME}
     PUBLIC 
         # pybind11
         pybind11::pybind11
-        depthai-core
+        depthai::core # Use non-opencv target as we use opencv-python in bindings
         hedley
 )
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,6 +89,7 @@ Now, pick a tutorial or code sample and start utilizing Gen2 capabilities
    samples/21_mobilenet_decoding_on_device.rst
    samples/22_tiny_tolo_v3_decoding_on_device.rst
    samples/23_autoexposure_roi.rst
+   samples/24_opencv_support.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/samples/24_opencv_support.rst
+++ b/docs/source/samples/24_opencv_support.rst
@@ -1,0 +1,31 @@
+24 - OpenCV support
+=========================
+
+This example shows API which exposes both numpy and OpenCV compatible image types for eaiser usage.
+It uses ColorCamera node to retrieve both BGR interleaved 'preview' and NV12 encoded 'video' frames.
+Both are displayed using functions `getFrame` and `getBgrFrame`.
+
+Setup
+#####
+
+Please run the following command to install the required dependencies
+
+.. code-block:: bash
+
+  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==0.0.2.1+9b7d9364ccb94e26c8754a2e0a69b2dafe6de145 numpy==1.19.5 opencv-python==4.5.1.48
+
+For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
+
+This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to work - you can download it from
+`here <https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet.blob>`__
+
+Source code
+###########
+
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/24_opencv_support.py>`__
+
+.. literalinclude:: ../../../examples/24_opencv_support.py
+   :language: python
+   :linenos:
+
+.. include::  /includes/footer-short.rst

--- a/examples/01_rgb_preview.py
+++ b/examples/01_rgb_preview.py
@@ -13,6 +13,7 @@ cam_rgb.setPreviewSize(300, 300)
 cam_rgb.setBoardSocket(dai.CameraBoardSocket.RGB)
 cam_rgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
 cam_rgb.setInterleaved(False)
+cam_rgb.setColorOrder(dai.ColorCameraProperties.ColorOrder.RGB)
 
 # Create output
 xout_rgb = pipeline.createXLinkOut()
@@ -29,12 +30,9 @@ with dai.Device(pipeline) as device:
 
     while True:
         in_rgb = q_rgb.get()  # blocking call, will wait until a new data has arrived
-        # data is originally represented as a flat 1D array, it needs to be converted into HxWxC form
-        shape = (3, in_rgb.getHeight(), in_rgb.getWidth())
-        frame_rgb = in_rgb.getData().reshape(shape).transpose(1, 2, 0).astype(np.uint8)
-        frame_rgb = np.ascontiguousarray(frame_rgb)
-        # frame is transformed and ready to be shown
-        cv2.imshow("rgb", frame_rgb)
+
+        # Retrieve 'bgr' (opencv format) frame
+        cv2.imshow("bgr", in_rgb.getBgrFrame())
 
         if cv2.waitKey(1) == ord('q'):
             break

--- a/examples/24_opencv_support.py
+++ b/examples/24_opencv_support.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import cv2
+import depthai as dai
+import numpy as np
+
+# Start defining a pipeline
+pipeline = dai.Pipeline()
+
+# Define a source - color camera
+cam_rgb = pipeline.createColorCamera()
+cam_rgb.setPreviewSize(300, 300)
+cam_rgb.setBoardSocket(dai.CameraBoardSocket.RGB)
+cam_rgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
+cam_rgb.setInterleaved(True)
+cam_rgb.setColorOrder(dai.ColorCameraProperties.ColorOrder.BGR)
+
+# Create output
+xout_video = pipeline.createXLinkOut()
+xout_video.setStreamName("video")
+xout_preview = pipeline.createXLinkOut()
+xout_preview.setStreamName("preview")
+
+cam_rgb.preview.link(xout_preview.input)
+cam_rgb.video.link(xout_video.input)
+
+# Pipeline defined, now the device is connected to
+with dai.Device(pipeline) as device:
+    # Start pipeline
+    device.startPipeline()
+
+    while True:
+        # Get preview and video frames
+        preview = device.getOutputQueue('preview').get()
+        video = device.getOutputQueue('video').get()
+
+        # Show 'preview' frame as is (already in correct format, no copy is made)
+        cv2.imshow("preview", preview.getFrame())
+        # Get BGR frame from NV12 encoded video frame to show with opencv
+        cv2.imshow("video", video.getBgrFrame())
+
+        if cv2.waitKey(1) == ord('q'):
+            break

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -79,6 +79,7 @@ if(DEPTHAI_PYTHON_TEST_EXAMPLES)
     dai_add_python_test(20_color_rotate_warp 20_color_rotate_warp.py)
     dai_add_python_test(21_mobilenet_device_side_decoding 21_mobilenet_device_side_decoding.py "${mobilenet_blob}")
     dai_add_python_test(22_tiny_yolo_v3_device_side_decoding 22_tiny_yolo_v3_device_side_decoding.py "${tiny_yolo_v3_blob}")
-
+    dai_add_python_test(23_autoexposure_roi 23_autoexposure_roi.py "${mobilenet_blob}")
+    dai_add_python_test(24_opencv_support 24_opencv_support.py)
 
 endif()

--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -401,6 +401,16 @@ void DatatypeBindings::bind(pybind11::module& m){
                     dtype = py::dtype::of<uint8_t>();
                 break;
 
+                case ImgFrame::Type::GRAYF16:
+                    shape = {img.getHeight(), img.getWidth()};  
+                    dtype = py::dtype("half");
+                break;
+
+                case ImgFrame::Type::RAW16:
+                    shape = {img.getHeight(), img.getWidth()};  
+                    dtype = py::dtype::of<uint16_t>();
+                break;
+
                 case ImgFrame::Type::RGBF16F16F16i:
                 case ImgFrame::Type::BGRF16F16F16i:
                     shape = {img.getHeight(), img.getWidth(), 3};


### PR DESCRIPTION
Related core changes: https://github.com/luxonis/depthai-core/pull/53

This is a complementary change to depthai-core, but uses opencv-python module instead of its own opencv library.

Also added alias for RawImgFrame::Type and RawImgFrame::Specs -> ImgFrame::Type and ImgFrame::Specs