### PR TITLE
Gen2 - Input queue size capability

### DIFF
--- a/examples/16_device_queue_event.py
+++ b/examples/16_device_queue_event.py
@@ -44,7 +44,7 @@ with dai.Device(pipeline) as device:
 
         # try getting that message from queue with name specified by the event
         # Note: number of events doesn't necessarily match number of messages in queues
-        # because queues can be set to non-blocking (overwriting) behaviour
+        # because queues can be set to non-blocking (overwriting) behavior
         message = device.getOutputQueue(queueName).tryGet()
 
         # process separately

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,7 +29,7 @@ if(DEPTHAI_PYTHON_TEST_EXAMPLES)
     hunter_private_data(
         URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet-ssd_6_shaves.blob"
         SHA1 "c72a4902416be329fb0b455d0dcf8fb4f680aff7"
-        FILE "mobilenet.blob"
+        FILE "mobilenet-ssd_6_shaves.blob"
         LOCATION mobilenet_blob
     )
 

--- a/src/pipeline/NodeBindings.cpp
+++ b/src/pipeline/NodeBindings.cpp
@@ -36,6 +36,8 @@ void NodeBindings::bind(pybind11::module& m){
     py::class_<Node::Input>(pyNode, "Input")
         .def("setBlocking", &Node::Input::setBlocking)
         .def("getBlocking", &Node::Input::getBlocking)
+        .def("setQueueSize", &Node::Input::setQueueSize)
+        .def("getQueueSize", &Node::Input::getQueueSize)
     ;
     // Node::Output bindings
     py::class_<Node::Output>(pyNode, "Output")


### PR DESCRIPTION
Related: https://github.com/luxonis/depthai-core/pull/59
Added `setQueueSize` and `getQueueSize` to explicitly set queue size and retrieve final queue size.
Also modified file location to not clash with `depthai-core`