### PR TITLE
Gen2 detach removal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2) # For Hunter
+cmake_minimum_required(VERSION 3.4) # For Hunter
 
 # Set defaults
 # PIC toolchain as we are building a shared library
@@ -6,11 +6,17 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/cmake/toolchain/pic.cmake" C
 # Build dependencies as 'Release' only by default
 set(HUNTER_CONFIGURATION_TYPES "Release" CACHE STRING "Hunter dependencies list of build configurations")
 
+# Generate combined Hunter config
+file(READ depthai-core/cmake/Hunter/config.cmake depthai_core_hunter_config)
+file(READ cmake/Hunter/config.cmake hunter_config)
+string(CONCAT final_hunter_config ${depthai_core_hunter_config} "\n\n" ${hunter_config})
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated/Hunter/config.cmake ${final_hunter_config})
+
 include("cmake/HunterGate.cmake")
 HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.23.258.tar.gz"
     SHA1 "062a19ab13ce8dffa9a882b6ce3e43bdabdf75d3"
-    FILEPATH ${CMAKE_CURRENT_LIST_DIR}/depthai-core/cmake/Hunter/config.cmake # Add depthai-core config (hunter limitation)
+    FILEPATH ${CMAKE_CURRENT_BINARY_DIR}/generated/Hunter/config.cmake # Combined config
 )
 
 # Move binary dir if windows, to shorten the path

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,0 +1,7 @@
+# Temporary pybind11 2.6.3dev1 chrono bindings patch
+hunter_config(
+    pybind11
+    VERSION "2.6.3dev1"
+    URL "https://github.com/bstaletic/pybind11/archive/a4932c114a3a43c9d0157805a23c0c726e461b96.tar.gz"
+    SHA1 "e65484c0aa7dc3220123a7e48a50ae7a8cecdd1c"
+)

--- a/examples/cmake/ExecuteTestTimeout.cmake
+++ b/examples/cmake/ExecuteTestTimeout.cmake
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
 
-# TODO (themarpe) - cross platform timeout
-
 # Parse out arguments
 foreach(_arg RANGE ${CMAKE_ARGC})
     if(append)
@@ -23,12 +21,14 @@ if(DEFINED ENV{TEST_TIMEOUT})
     set(TIMEOUT_SECONDS $ENV{TEST_TIMEOUT})
 endif()
 
-# Execute the example
-execute_process(COMMAND timeout -s SIGINT -k 5 ${TIMEOUT_SECONDS} ${arguments} RESULT_VARIABLE error_variable)
-message(STATUS "After timeout, ${PATH_TO_TEST_EXECUTABLE} produced the following exit code: ${error_variable}")
+# Execute the example (SIGTERM for now, could be improved with SIGINT -> SIGKILL)
+if(TIMEOUT_SECONDS GREATER 0)
+    execute_process(COMMAND ${arguments} TIMEOUT ${TIMEOUT_SECONDS} RESULT_VARIABLE error_variable)
+else()
+    execute_process(COMMAND ${arguments} RESULT_VARIABLE error_variable)
+endif()
 
-# After that, wait for ~3 seconds
-#execute_process(COMMAND sleep 3)
+message(STATUS "After process executed, ${PATH_TO_TEST_EXECUTABLE} produced the following exit code: ${error_variable}")
 
 if(error_variable MATCHES "timeout" OR error_variable EQUAL 128 OR error_variable EQUAL 124)
     # Okay

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -215,7 +215,7 @@ void DeviceBindings::bind(pybind11::module& m){
             return events[0];
         }, py::arg("timeout") = std::chrono::microseconds(-1))
 
-        .def("setCallback", DeviceWrapper::wrap(&Device::setCallback), py::arg("name"), py::arg("callback"))
+        //.def("setCallback", DeviceWrapper::wrap(&Device::setCallback), py::arg("name"), py::arg("callback"))
         .def("setLogLevel", DeviceWrapper::wrap(&Device::setLogLevel), py::arg("level"))
         .def("getLogLevel", DeviceWrapper::wrap(&Device::getLogLevel))
         .def("setSystemInformationLoggingRate", DeviceWrapper::wrap(&Device::setSystemInformationLoggingRate), py::arg("rateHz"))

--- a/src/DeviceBootloaderBindings.cpp
+++ b/src/DeviceBootloaderBindings.cpp
@@ -23,6 +23,11 @@ void DeviceBootloaderBindings::bind(pybind11::module& m){
         ;
 
     deviceBootloader
+        // Python only methods
+        .def("__enter__", [](py::object obj){ return obj; })
+        .def("__exit__", [](DeviceBootloader& bl, py::object type, py::object value, py::object traceback) { bl.close(); })
+        .def("close", &DeviceBootloader::close)
+
         .def_static("getFirstAvailableDevice", &DeviceBootloader::getFirstAvailableDevice)
         .def_static("getAllAvailableDevices", &DeviceBootloader::getAllAvailableDevices)
         .def_static("saveDepthaiApplicationPackage", &DeviceBootloader::saveDepthaiApplicationPackage, py::arg("path"), py::arg("pipeline"), py::arg("pathToCmd") = "")


### PR DESCRIPTION
Some support changes for core thread detach removal
 - Removed `DeviceWrapper` in favor of core `close` for `Device` and added context manager for `DeviceBootloader`
 - Updated pybind11 to 2.6.3 which issues a fix for chrono bindings (fixes `getQeueuEvents` class of functions) (as well as Python3.9 incompatibility)
 - Enabled support for cross platform testing