### PR TITLE
Updates from website

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,6 +66,7 @@ Now, pick a tutorial or code sample and start utilizing Gen2 capabilities
    tutorials/hello_world.rst
    tutorials/multiple.rst
    tutorials/local_convert_openvino.rst
+   tutorials/pretrained_openvino.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,22 +1,40 @@
-Installation - Python
-=====================
+Installation
+============
 
-Instructions for installing, upgrading, and using the DepthAI Python API.
+Please :ref:`install the necessary dependencies <Supported Platforms>` for your
+platform by referring to the table below. Once installed you can :ref:`install
+the DepthAI library <Install from PyPI>`.
+
+We are constantly striving to improve how we release our software to keep up
+with countless platforms and the numerous ways to package it.  If you do not
+see a particular platform or package format listed below please reach out to
+us on `Discord <https://discord.com/channels/790680891252932659/794255653870370857>`__
+or on `Github <https://github.com/luxonis/depthai>`__.
 
 Supported Platforms
 ###################
 
-The DepthAI Gen2 API python module is prebuilt for **Ubuntu**, **macOS** and **Windows**.
-For other operating systems and/or Python versions, DepthAI can be :ref:`built from source <Other installation methods>`.
+We keep up-to-date, pre-compiled, libraries for the following platforms.  Note that a new change is that for Ubuntu now also work unchanged for the Jetson/Xavier series:
 
-Installing system dependencies
-##############################
+======================== =========================================== ================================================= ================================================================================
+Platform                 Instructions                                Tutorial                                          Support
+======================== =========================================== ================================================= ================================================================================
+Windows 10               :ref:`Platform dependencies <Windows>`      `Video tutorial <https://youtu.be/ekopKJfcWiE>`__ `Discord <https://discord.com/channels/790680891252932659/798284448323731456>`__
+macOS                    :ref:`Platform dependencies <macOS>`        `Video tutorial <https://youtu.be/0RGmmjed3Hc>`__ `Discord <https://discord.com/channels/790680891252932659/798283911989690368>`__
+Ubuntu & Jetson/Xavier   :ref:`Platform dependencies <Ubuntu>`       `Video tutorial <https://youtu.be/QXeXMaxj4cM>`__ `Discord <https://discord.com/channels/790680891252932659/798302162160451594>`__
+Raspberry Pi             :ref:`Platform dependencies <Raspberry Pi>` `Video tutorial <https://youtu.be/BpUMT-xqwqE>`__ `Discord <https://discord.com/channels/790680891252932659/798302708070350859>`__
+======================== =========================================== ================================================= ================================================================================
 
-A couple of basic system dependencies are required to run the DepthAI library. Most of them should be already installed
-in most of the systems, but in case they are not, we prepared :download:`an install script </_static/install_dependencies.sh>`
-that will make sure all dependencies are installed, along with convenient development/programming tools.
-There are also video guides available for macOS (`here <https://youtu.be/0RGmmjed3Hc>`__), Raspberry Pi (`here <https://youtu.be/BpUMT-xqwqE>`__),
-Ubuntu (`here <https://youtu.be/QXeXMaxj4cM>`__), and Windows 10 (`here <https://youtu.be/ekopKJfcWiE>`__).
+And the following platforms are also supported by a combination of the community and Luxonis.
+
+====================== ===================================================== ================================================================================
+Platform               Instructions                                          Support
+====================== ===================================================== ================================================================================
+Fedora                                                                       `Discord <https://discord.com/channels/790680891252932659/798592589905264650>`__
+Robot Operating System                                                       `Discord <https://discord.com/channels/790680891252932659/795749142793420861>`__
+Windows 7              :ref:`WinUSB driver <Windows 7>`                      `Discord <https://discord.com/channels/790680891252932659/798284448323731456>`__
+Docker                 :ref:`Pull and run official images <Docker>`          `Discord <https://discord.com/channels/790680891252932659/796794747275837520>`__
+====================== ===================================================== ================================================================================
 
 macOS
 *****
@@ -27,9 +45,7 @@ macOS
 
 Close and re-open the terminal window after this command.
 
-The script also works on M1 Macs, Homebrew being installed under Rosetta 2, as some Python packages are still missing native M1 support.
-In case you already have Homebrew installed natively and things don't work, see `here <https://github.com/luxonis/depthai/issues/299#issuecomment-757110966>`__
-for some additional troubleshooting steps.
+The script also works on M1 Macs, Homebrew being installed under Rosetta 2, as some Python packages are still missing native M1 support.  In case you already have Homebrew installed natively and things don't work, see `here <https://github.com/luxonis/depthai/issues/299#issuecomment-757110966>`__ for some additional troubleshooting steps.
 
 Note that if the video streaming window does not appear consider running the
 following:
@@ -50,16 +66,31 @@ Raspberry Pi OS
 Ubuntu
 ******
 
+Note that these Ubuntu instructions also work for the **Jetson** and **Xavier** series.
+
 .. code-block:: bash
 
   sudo wget -qO- http://docs.luxonis.com/_static/install_dependencies.sh | bash
 
+openSUSE
+********
+
+For openSUSE, available `in this official article <https://en.opensuse.org/SDB:Install_OAK_AI_Kit>`__ how to install the OAK device on the openSUSE platform.
+
 Windows
 *******
 
-- Right click on Start
-- Choose Windows PowerShell (Admin)
-- Install Chocolatey package manager (similar to Homebrew for macOS):
+We recommend using the Chocolatey package manager to install DepthAI's
+dependencies on Windows. Chocolatey is very similar to Homebrew for macOS.
+Alternatively, it is also possible to :ref:`install DepthAI and its
+dependencies manually <Manually install DepthAI on Windows>`, although it can
+be more time consuming and error prone.
+
+To `install Chocolatey <https://docs.chocolatey.org/en-us/choco/setup>`__ and
+use it to install DepthAI's dependencies do the following:
+
+- Right click on `Start`
+- Choose `Windows PowerShell (Admin)` and run the following:
 
 .. code-block:: bash
 
@@ -72,86 +103,110 @@ Windows
 
   choco install cmake git python pycharm-community -y
 
-Enabling the USB device (only on Linux)
-#######################################
+Windows 7
+---------
 
-Since the DepthAI is a USB device, in order to communicate with it on the systems that use :code:`udev` tool, you
-need to add the udev rules in order to make the device accessible.
+Although we do not officially support Windows 7, members of the community `have
+had success <https://discuss.luxonis.com/d/105-run-on-win7-sp1-x64-manual-instal-usb-driver>`__ manually installing WinUSB using `Zadig
+<https://zadig.akeo.ie/>`__. After connecting your DepthAI device look for a
+device with :code:`USB ID: 03E7 2485` and install the WinUSB driver by
+selecting `WinUSB(v6.1.7600.16385)` and then `Install WCID Driver`.
 
-The following command will add a new udev rule to your system
+Docker
+******
+
+We maintain a Docker image containing DepthAI, it's dependencies and helpful
+tools in the `luxonis/depthai-library <https://hub.docker.com/r/luxonis/depthai-library>`__
+repository on Docker Hub. It builds upon the `luxonis/depthai-base
+<https://hub.docker.com/r/luxonis/depthai-base>`__ image.
+
+Run the :code:`01_rgb_preview.py` example inside a Docker container on a Linux host
+(with the X11 windowing system):
 
 .. code-block:: bash
 
-  echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' | sudo tee /etc/udev/rules.d/80-movidius.rules
-  sudo udevadm control --reload-rules && sudo udevadm trigger
+   docker pull luxonis/depthai-library
+   docker run --rm \
+       --privileged \
+       -v /dev/bus/usb:/dev/bus/usb \
+       --device-cgroup-rule='c 189:* rmw' \
+       -e DISPLAY=$DISPLAY \
+       -v /tmp/.X11-unix:/tmp/.X11-unix \
+       luxonis/depthai-library:latest \
+       python3 /depthai-python/examples/01_rgb_preview.py
 
-Install using pip
+To allow the container to update X11 you may need to run :code:`xhost local:root` on
+the host.
+
+Install from PyPI
 #################
 
-Our packages are available to download using our `Artifactory server <https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/>`__.
-These are built for every commit in the `depthai-python <https://github.com/luxonis/depthai-python/tree/gen2_develop>`__ repository and are suffixed
-with a commit SHA.
+Our packages are distributed `via PyPi <https://pypi.org/project/depthai/>`__, to install it in your environment use
 
-Note that we recommend installing the dependencies in a virtual environment, so that they don't interfere with other Python
-tools/environments on your system.
+.. code-block:: bash
 
-- For development machines like Mac/Windows/Ubuntu/etc., we recommend the `PyCharm <https://www.jetbrains.com/pycharm/>`__ IDE, as it automatically makes/manages virtual environments for you, along with a bunch of other benefits.  Alternatively, :code:`conda`, :code:`pipenv`, or :code:`virtualenv` could be used directly (and/or with your preferred IDE).
-- For installations on resource-constrained systems, such as the Raspberry Pi or other small Linux systems, we recommend :code:`conda`, :code:`pipenv`, or :code:`virtualenv`.  To set up a virtual environment with :code:`virtualenv`, run
-
-  .. code-block:: bash
-
-    virtualenv venv
-    source venv/bin/activate
-
-Using a virtual environment (or system-wide, if you prefer), run the following to install the DepthAI using pip:
-
-#. Pick the preferred commit from `commit list <https://github.com/luxonis/depthai-python/commits/gen2_develop>`__
-
-#. Upgrade pip
-
-  .. code-block:: bash
-
-    python3 -m pip install -U pip
-
-#. Install DepthAI Gen2 API, adding commit SHA at the end of a package name, in form of :code:`depthai==0.0.2.1+<sha>`
-
-  .. code-block:: bash
-    :substitutions:
-
-    python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release|
+  python3 -m pip install depthai
 
 For other installation options, see :ref:`other installation options <Other installation methods>`.
 
 Test installation
 #################
 
-We have `a set of examples <https://github.com/luxonis/depthai-python/tree/gen2_develop/examples>`__ that should help you verify if your setup was correct.
+We have `a set of examples <https://github.com/luxonis/depthai-python/tree/develop/examples>`__ that should help you verify if your setup was correct.
 
-First, clone the `depthai-python <https://github.com/luxonis/depthai-python/tree/gen2_develop>`__ repository and change directory into this repo:
+First, clone the `depthai-python <https://github.com/luxonis/depthai-python/tree/develop>`__ repository and change directory into this repo:
 
 .. code-block:: bash
 
-  git clone https://github.com/luxonis/depthai-python.git --branch gen2_develop
+  git clone https://github.com/luxonis/depthai-python.git
   cd depthai-python
 
-Now, run the :code:`01_rgb_preview.py` script from within :code`examples` directory to make sure everything is working:
+Next install the requirements for this repository.
+Note that we recommend installing the dependencies in a virtual environment, so that they don't interfere with other Python
+tools/environments on your system.
+
+- For development machines like Mac/Windows/Ubuntu/etc., we recommend the `PyCharm <https://www.jetbrains.com/pycharm/>`__ IDE, as it automatically makes/manages virtual environments for you, along with a bunch of other benefits.  Alternatively, :code:`conda`, :code:`pipenv`, or :code:`virtualenv` could be used directly (and/or with your preferred IDE).
+- For installations on resource-constrained systems, such as the Raspberry Pi or other small Linux systems, we recommend :code:`conda`, :code:`pipenv`, or :code:`virtualenv`.  To set up a virtual environment with :code:`virtualenv`, run :code:`virtualenv venv && source venv/bin/activate`.
+
+Using a virtual environment (or system-wide, if you prefer), run the following to install the requirements for this example repository:
+
+.. code-block:: bash
+
+  python3 -m pip install -r requirements.txt
+
+Now, run the :code:`01_rgb_preview.py` script from within :code:`examples` directory to make sure everything is working:
 
 .. code-block:: bash
 
   python3 examples/01_rgb_preview.py
 
-If all goes well a small window video display will appear with color camera preview
+If all goes well a small window video display should appear.  And example is shown below:
+
+.. raw:: html
+
+    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+        <iframe src="https://www.youtube.com/embed/WP-Vo-awT9A" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+    </div>
 
 
-.. warning::
+Run Other Examples
+##################
 
-  Some of the examples needs additional setup to be ran. Please be sure to follow `setup instructions in README.md <https://github.com/luxonis/depthai-python/tree/gen2_develop/examples#depthai-python-examples>`__
-  to run different examples
+After you have run this example, you can run other examples to learn about DepthAI possibilities. You can also proceed to:
+
+- Our tutorials, starting with a Hello World tutorial explaining the API usage step by step (:ref:`here <Hello World>`)
+- Our experiments, containing implementations of various user use cases on DepthAI (`here <https://github.com/luxonis/depthai-experiments>`__)
+
+You can also proceed below to learn how to convert your own neural network to run on DepthAI.
+
+And we also have online model training below, which shows you how to train and convert models for DepthAI:
+
+- Online ML Training and model Conversion: `HERE <https://github.com/luxonis/depthai-ml-training/tree/master/colab-notebooks>`__
 
 Other installation methods
 ##########################
 
-To get the latest features from our source code, you can go ahead and compile depthai package manually.
+To get the latest and yet unreleased features from our source code, you can go ahead and compile depthai package manually.
 
 Dependencies to build from source
 *********************************
@@ -175,7 +230,7 @@ On Debian based systems (Raspberry Pi OS, Ubuntu, ...) these can be acquired by 
 macOS (Mac OS X)
 ----------------
 
-Assuming a stock Mac OS X install, `depthai-python <https://github.com/luxonis/depthai-python/tree/gen2_develop>`__ library needs following dependencies
+Assuming a stock Mac OS X install, `depthai-python <https://github.com/luxonis/depthai-python>`__ library needs following dependencies
 
 - Homebrew (If it's not installed already)
 
@@ -183,22 +238,34 @@ Assuming a stock Mac OS X install, `depthai-python <https://github.com/luxonis/d
 
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
-- Python, libusb, CMake, wget
+- Python, :code:`libusb`, CMake, :code:`wget`
 
   .. code-block:: bash
 
       brew install coreutils python3 cmake libusb wget
 
-And now you're ready to clone the `depthai-python gen2_develop branch <https://github.com/luxonis/depthai-python/tree/gen2_develop>`__ from Github and build it for Mac OS X.
+And now you're ready to clone the `depthai-python <https://github.com/luxonis/depthai-python>`__ from Github and build it for Mac OS X.
+
+Install using GitHub commit
+***************************
+
+Pip allows users to install the packages from specific commits, even if they are not yet released on PyPi.
+
+To do so, use the command below - and be sure to replace the :code:`<commit_sha>` with the correct commit hash `from here <https://github.com/luxonis/depthai-python/commits>`__
+
+.. code-block:: bash
+
+    python3 -m pip install git+https://github.com/luxonis/depthai-python.git@<commit_sha>
 
 Using/Testing a Specific Branch/PR
 **********************************
 
 From time to time, it may be of interest to use a specific branch.  This may occur, for example,
 because we have listened to your feature request and implemented a quick implementation in a branch.
-Or it could be to get early access to a feature that is soaking in for stability purposes before being merged.
+Or it could be to get early access to a feature that is soaking in our :code:`develop` for stability purposes before being merged into :code:`main`
+(:code:`develop` is the branch we use to soak new features before merging them into :code:`main`):
 
-So when working in the `depthai-python <https://github.com/luxonis/depthai-python/tree/gen2_develop>`__ repository, using a branch can be accomplished
+So when working in the `depthai-python <https://github.com/luxonis/depthai-python>`__ repository, using a branch can be accomplished
 with the following commands.
 
 Prior to running the following, you can either clone the repository independently
@@ -220,7 +287,23 @@ To do so, first download the repository and then add the package to your python 
 
 .. code-block:: bash
 
-  git clone https://github.com/luxonis/depthai-python.git --branch gen2_develop
+  git clone https://github.com/luxonis/depthai-python.git
   cd depthai-python
   git submodule update --init --recursive
   python3 setup.py develop  # you may need to add sudo if using system interpreter instead of virtual environment
+
+If you want to use other branch (e.g. :code:`develop`) than default (:code:`main`), you can do so by typing
+
+.. code-block:: bash
+
+  git checkout develop  # replace the "develop" with a desired branch name
+  git submodule update --recursive
+  python3 setup.py develop
+
+Or, if you want to checkout a specific commit, type
+
+.. code-block:: bash
+
+  git checkout <commit_sha>
+  git submodule update --recursive
+  python3 setup.py develop

--- a/docs/source/samples/01_rgb_preview.rst
+++ b/docs/source/samples/01_rgb_preview.rst
@@ -22,7 +22,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -30,7 +30,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/01_rgb_preview.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/01_rgb_preview.py>`__
 
 .. literalinclude:: ../../../examples/01_rgb_preview.py
    :language: python

--- a/docs/source/samples/02_mono_preview.rst
+++ b/docs/source/samples/02_mono_preview.rst
@@ -21,7 +21,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -29,7 +29,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/02_mono_preview.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/02_mono_preview.py>`__
 
 .. literalinclude:: ../../../examples/02_mono_preview.py
    :language: python

--- a/docs/source/samples/03_depth_preview.rst
+++ b/docs/source/samples/03_depth_preview.rst
@@ -22,7 +22,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -30,7 +30,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/03_depth_preview.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/03_depth_preview.py>`__
 
 .. literalinclude:: ../../../examples/03_depth_preview.py
    :language: python

--- a/docs/source/samples/04_rgb_encoding.rst
+++ b/docs/source/samples/04_rgb_encoding.rst
@@ -30,7 +30,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -38,7 +38,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/04_rgb_encoding.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/04_rgb_encoding.py>`__
 
 .. literalinclude:: ../../../examples/04_rgb_encoding.py
    :language: python

--- a/docs/source/samples/05_rgb_mono_encoding.rst
+++ b/docs/source/samples/05_rgb_mono_encoding.rst
@@ -28,7 +28,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -36,7 +36,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/05_rgb_mono_encoding.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/05_rgb_mono_encoding.py>`__
 
 .. literalinclude:: ../../../examples/05_rgb_mono_encoding.py
    :language: python

--- a/docs/source/samples/06_rgb_full_resolution_saver.rst
+++ b/docs/source/samples/06_rgb_full_resolution_saver.rst
@@ -27,7 +27,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -35,7 +35,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/06_rgb_full_resolution_saver.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/06_rgb_full_resolution_saver.py>`__
 
 .. literalinclude:: ../../../examples/06_rgb_full_resolution_saver.py
    :language: python

--- a/docs/source/samples/07_mono_full_resolution_saver.rst
+++ b/docs/source/samples/07_mono_full_resolution_saver.rst
@@ -21,7 +21,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -29,7 +29,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/07_mono_full_resolution_saver.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/07_mono_full_resolution_saver.py>`__
 
 .. literalinclude:: ../../../examples/07_mono_full_resolution_saver.py
    :language: python

--- a/docs/source/samples/08_rgb_mobilenet.rst
+++ b/docs/source/samples/08_rgb_mobilenet.rst
@@ -21,7 +21,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -32,7 +32,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/08_rgb_mobilenet.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/08_rgb_mobilenet.py>`__
 
 .. literalinclude:: ../../../examples/08_rgb_mobilenet.py
    :language: python

--- a/docs/source/samples/09_mono_mobilenet.rst
+++ b/docs/source/samples/09_mono_mobilenet.rst
@@ -21,7 +21,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -32,7 +32,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/09_mono_mobilenet.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/09_mono_mobilenet.py>`__
 
 .. literalinclude:: ../../../examples/09_mono_mobilenet.py
    :language: python

--- a/docs/source/samples/10_mono_depth_mobilenetssd.rst
+++ b/docs/source/samples/10_mono_depth_mobilenetssd.rst
@@ -22,7 +22,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -33,7 +33,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/10_mono_depth_mobilenetssd.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/10_mono_depth_mobilenetssd.py>`__
 
 .. literalinclude:: ../../../examples/10_mono_depth_mobilenetssd.py
    :language: python

--- a/docs/source/samples/11_rgb_encoding_mono_mobilenet.rst
+++ b/docs/source/samples/11_rgb_encoding_mono_mobilenet.rst
@@ -29,7 +29,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -40,7 +40,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/11_rgb_encoding_mono_mobilenet.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/11_rgb_encoding_mono_mobilenet.py>`__
 
 .. literalinclude:: ../../../examples/11_rgb_encoding_mono_mobilenet.py
    :language: python

--- a/docs/source/samples/12_rgb_encoding_mono_mobilenet_depth.rst
+++ b/docs/source/samples/12_rgb_encoding_mono_mobilenet_depth.rst
@@ -31,7 +31,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -42,7 +42,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/12_rgb_encoding_mono_mobilenet_depth.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/12_rgb_encoding_mono_mobilenet_depth.py>`__
 
 .. literalinclude:: ../../../examples/12_rgb_encoding_mono_mobilenet_depth.py
    :language: python

--- a/docs/source/samples/13_encoding_max_limit.rst
+++ b/docs/source/samples/13_encoding_max_limit.rst
@@ -29,7 +29,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -37,7 +37,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/13_encoding_max_limit.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/13_encoding_max_limit.py>`__
 
 .. literalinclude:: ../../../examples/13_encoding_max_limit.py
    :language: python

--- a/docs/source/samples/14_color_camera_control.rst
+++ b/docs/source/samples/14_color_camera_control.rst
@@ -27,7 +27,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -35,7 +35,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/14_color_camera_control.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/14_color_camera_control.py>`__
 
 .. literalinclude:: ../../../examples/14_color_camera_control.py
    :language: python

--- a/docs/source/samples/15_rgb_mobilenet_4k.rst
+++ b/docs/source/samples/15_rgb_mobilenet_4k.rst
@@ -23,7 +23,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -34,7 +34,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/15_rgb_mobilenet_4k.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/15_rgb_mobilenet_4k.py>`__
 
 .. literalinclude:: ../../../examples/15_rgb_mobilenet_4k.py
    :language: python

--- a/docs/source/samples/16_device_queue_event.rst
+++ b/docs/source/samples/16_device_queue_event.rst
@@ -22,7 +22,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -30,7 +30,7 @@ For additional information, please follow :ref:`Python API installation guide <I
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/16_device_queue_event.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/16_device_queue_event.py>`__
 
 .. literalinclude:: ../../../examples/16_device_queue_event.py
    :language: python

--- a/docs/source/samples/17_video_mobilenet.rst
+++ b/docs/source/samples/17_video_mobilenet.rst
@@ -24,7 +24,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -37,7 +37,7 @@ and `construction_vest.mp4 <https://artifacts.luxonis.com/artifactory/luxonis-de
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/17_video_mobilenet.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/17_video_mobilenet.py>`__
 
 .. literalinclude:: ../../../examples/17_video_mobilenet.py
    :language: python

--- a/docs/source/samples/18_rgb_encoding_mobilenet.rst
+++ b/docs/source/samples/18_rgb_encoding_mobilenet.rst
@@ -29,7 +29,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -40,7 +40,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/18_rgb_encoding_mobilenet.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/18_rgb_encoding_mobilenet.py>`__
 
 .. literalinclude:: ../../../examples/18_rgb_encoding_mobilenet.py
    :language: python

--- a/docs/source/samples/21_mobilenet_decoding_on_device.rst
+++ b/docs/source/samples/21_mobilenet_decoding_on_device.rst
@@ -20,7 +20,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -31,7 +31,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/21_mobilenet_device_side_decoding.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/21_mobilenet_device_side_decoding.py>`__
 
 .. literalinclude:: ../../../examples/21_mobilenet_device_side_decoding.py
    :language: python

--- a/docs/source/samples/22_tiny_tolo_v3_decoding_on_device.rst
+++ b/docs/source/samples/22_tiny_tolo_v3_decoding_on_device.rst
@@ -24,7 +24,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -35,7 +35,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/22_tiny_yolo_v3_device_side_decoding.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/22_tiny_yolo_v3_device_side_decoding.py>`__
 
 .. literalinclude:: ../../../examples/22_tiny_yolo_v3_device_side_decoding.py
    :language: python

--- a/docs/source/samples/23_autoexposure_roi.rst
+++ b/docs/source/samples/23_autoexposure_roi.rst
@@ -21,7 +21,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -32,7 +32,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/23_autoexposure_roi.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/23_autoexposure_roi.py>`__
 
 .. literalinclude:: ../../../examples/23_autoexposure_roi.py
    :language: python

--- a/docs/source/samples/24_opencv_support.rst
+++ b/docs/source/samples/24_opencv_support.rst
@@ -14,7 +14,7 @@ Please run the following command to install the required dependencies
 .. code-block:: bash
   :substitutions:
 
-  python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ depthai==|release| numpy==1.19.5 opencv-python==4.5.1.48
+  python3 -m pip install depthai==2.0.0.0 numpy==1.19.5 opencv-python==4.5.1.48
 
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
@@ -25,7 +25,7 @@ This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to wo
 Source code
 ###########
 
-Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/gen2_develop/examples/24_opencv_support.py>`__
+Also `available on GitHub <https://github.com/luxonis/depthai-python/blob/main/examples/24_opencv_support.py>`__
 
 .. literalinclude:: ../../../examples/24_opencv_support.py
    :language: python

--- a/docs/source/tutorials/hello_world.rst
+++ b/docs/source/tutorials/hello_world.rst
@@ -30,7 +30,7 @@ Code Overview
 
 The :code:`depthai` Python module provides access to your board's 4K 60 Hz color camera.
 We'll display a video stream from this camera to your desktop.
-You can find the `complete source code for this tutorial on GitHub <https://github.com/luxonis/depthai-tutorials/tree/gen2/1-hello-world>`__.
+You can find the `complete source code for this tutorial on GitHub <https://github.com/luxonis/depthai-tutorials/tree/master/1-hello-world>`__.
 
 File Setup
 ##########
@@ -304,6 +304,6 @@ Putting it all together, only thing left to do is to run the file we've prepared
 
   python3 hello_world.py
 
-You're on your way! You can find the `complete code for this tutorial on GitHub <https://github.com/luxonis/depthai-tutorials/blob/gen2/1-hello-world/hello_world.py>`__.
+You're on your way! You can find the `complete code for this tutorial on GitHub <https://github.com/luxonis/depthai-tutorials/blob/master/1-hello-world/hello_world.py>`__.
 
 .. include::  /includes/footer-short.rst

--- a/docs/source/tutorials/pretrained_openvino.rst
+++ b/docs/source/tutorials/pretrained_openvino.rst
@@ -128,6 +128,17 @@ The flow we walked through works for other pre-trained object detection models i
 - person detection for retail environments (:code:`person-detection-retail-0013`)
 - vehicle detection for driver-assistance (:code:`vehicle-detection-adas-0002`)
 - vehicle and license plate detection (:code:`vehicle-license-plate-detection-barrier-0106`)
+- Human Pose Estimation (:code:`human-pose-estimation-0001`)
+- Pedestrian Detection (ADAS) (:code:`pedestrian-detection-adas-0002`)
+- Person, Vehicle and Bike Detection (:code:`person-vehicle-bike-detection-crossroad-1016`)
+- Age and Gender Recognition (:code:`age-gender-recognition-retail-0013`)
+- Pose Estimation on MobileNetV2 (:code:`mobileNetV2-PoseEstimation`)
+
+Models that can be deployed as first CNN in the argument (:code:`python3 depthai_demo.py -cnn <model>)
+(:code:`vehicle-detection-adas-0002,mobileNetV2-PoseEstimation,yolo-v3,vehicle-license-plate-detection-barrier-0106,age-gender-recognition-retail-0013,person-detection-retail-0013,human-pose-estimation-0001,face-detection-adas-0001,person-vehicle-bike-detection-crossroad-1016,openpose2,pedestrian-detection-adas-0002,tiny-yolo-v3,openpose,deeplabv3p_person,mobilenet-ssd,face-detection-retail-0004`)
+
+Models that can be deployed as second CNN in the argument (:code:`python3 depthai_demo.py -cnn <model_1> -cnn2 <model_2>`)
+(:code:`landmarks-regression-retail-0009,facial-landmarks-35-adas-0002,emotions-recognition-retail-0003`)
 
 Simply change the paths above to run the other models there, adding the correct labels (or funny ones, should you choose).
 

--- a/docs/source/tutorials/pretrained_openvino.rst
+++ b/docs/source/tutorials/pretrained_openvino.rst
@@ -1,8 +1,12 @@
 Use a Pre-trained OpenVINO model
 ================================
 
-In this tutorial, you'll learn how to detect faces in realtime, even on a low-powered Raspberry Pi. I'll introduce you
-to the OpenVINO model zoo and running models from this 'zoo'.
+.. warning::
+
+  This example is outdated and we're working on updating, please proceed with caution
+
+In this tutorial, you'll learn how to detect faces in real-time, even on a low-powered Raspberry Pi. I'll introduce you
+to the OpenVINO, the Open Model Zoo and show you how to run models.
 
 .. image:: /_static/images/tutorials/pretrained_openvino/face-1.png
   :alt: preview
@@ -12,45 +16,39 @@ Haven't heard of OpenVINO or the Open Model Zoo? I'll start with a quick introdu
 What is OpenVINO?
 #################
 
-Under-the-hood, DepthAI uses the Intel MyriadX chip to perform high-speed model inference. However, you can't just dump
-your neural net into the chip and get high-performance for free. That's where `OpenVINO <https://docs.openvinotoolkit.org/>`__
-comes in. OpenVINO is a free toolkit that converts a deep learning model into a format that runs on Intel Hardware.
-Once the model is converted, it's common to see Frames Per Second (FPS) improve by 25x or more. Are a couple of small
-steps worth a 25x FPS increase? Often, the answer is yes!
+
+Under-the-hood, DepthAI uses the Intel Myriad X to perform high-speed model inference. However, you can't just dump
+your neural net into the chip and get high-performance for free. That's where `OpenVINO
+<https://docs.openvinotoolkit.org/>`__ comes in. OpenVINO is a free toolkit that converts a deep learning model into a
+format that runs on Intel Hardware. Once the model is converted, it's common to see Frames Per Second (FPS) improve by
+25x or more. Are a couple of small steps worth a 25x FPS increase? Often, the answer is yes!
+
+Check the `OpenVINO toolkit website <https://software.intel.com/content/www/us/en/develop/tools/openvino-toolkit.html>`__
+for installation instructions. OpenVINO should be installed under `/opt/intel`. Verify that the version is supported by
+DepthAI (see :ref:`Is DepthAI OpenVINO Compatible? <Is DepthAI OpenVINO Compatible?>`).
 
 What is the Open Model Zoo?
 ###########################
 
-The `Open Model Zoo <https://github.com/opencv/open_model_zoo>`__ is a library of freely-available pre-trained models.
-Side note: in machine learning/AI the name for a collection of pre-trained models is called a 'model zoo'.
-The Zoo also contains scripts for downloading those models into a compile-ready format to run on DepthAI.
+In machine learning/AI the name for a collection of pre-trained models is called a "model zoo". The `Open Model Zoo
+<https://github.com/opencv/open_model_zoo>`__ is a library of freely-available pre-trained models. The Zoo also contains
+scripts for downloading those models into a compile-ready format to run on DepthAI.
 
-DepthAI is able to run many of the object detection models in the Zoo, and several are pre-included in the DepthAI Github.
-repository.  We will be using one such model in this tutorial, is face-detection-retail-0004 (pre-compiled
-`here <https://github.com/luxonis/depthai/tree/master/resources/nn/face-detection-retail-0004>`__ on our Github, and
-`here <https://docs.openvinotoolkit.org/2020.1/_models_intel_face_detection_retail_0004_description_face_detection_retail_0004.html>`__ on the OpenVINO model zoo).
+DepthAI is able to run many of the object detection models in the Zoo. Several of those models are included in the
+`DepthAI Github repositoy <https://github.com/luxonis/depthai/tree/master/resources/nn/>`__.
 
-We'll cover converting OpenVINO models to run on DepthAI in a later article.  For now, you can find the models we've
-pre-converted `here <https://github.com/luxonis/depthai/tree/master/resources/nn>`__ and brief instructions on how to do
-so `here <https://github.com/luxonis/depthai#conversion-of-existing-trained-models-into-intel-movidius-binary-format>`__.
+Clone the Open Model Zoo repository from Github and `install its dependencies
+<https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/downloader/README.md#prerequisites>`__.
+Optionally, add the scripts to your path:
 
-Dependencies
-############
+.. code-block:: bash
 
-.. warning::
-
-  Using the RPi Compute Edition or a pre-flashed DepthAI Raspberry Pi µSD card? **Skip this step**
-
-  All dependencies are installed and the repository is checked out to :code:`~/Desktop/depthai`.
-
-This tutorial has the same dependencies as the :ref:`Hello World Tutorial <hello_world_dependencies>` - that the DepthAI
-API has been installed and is accessible on the system.  See :ref:`here <Python API>` if you have not yet installed the API.
-
+    export PATH="${PATH}:${PWD}/open_model_zoo/tools/downloader/"
 
 Run DepthAI Default Model
 #########################
 
-The :code:`depthai.py` file can be modified directly to you do your bidding, or you can simply pass arguments to it for
+The :code:`depthai_demo.py` file can be modified directly to you do your bidding, or you can simply pass arguments to it for
 which models you want to run.
 
 For simplicity we will do the latter, simply passing arguments so that DepthAI runs the :code:`face-detection-retail-0004`
@@ -64,12 +62,12 @@ options a spin.  In this case we'll just pass in the same neural network that de
 
   python3 depthai_demo.py -dd
 
-This will then run the a typical demo MobileNetv1 SSD object detector trained on the `PASCAL 2007 VOC <http://host.robots.ox.ac.uk/pascal/VOC/voc2007/>`__ classes, which are:
+This will then run the a typical demo MobileNetv2 SSD object detector trained on the `PASCAL 2007 VOC <http://host.robots.ox.ac.uk/pascal/VOC/voc2007/>`__ classes, which are:
 
 - Person: person
 - Animal: bird, cat, cow, dog, horse, sheep
-- Vehicle: aeroplane, bicycle, boat, bus, car, motorbike, train
-- Indoor: bottle, chair, dining table, potted plant, sofa, tv/monitor
+- Vehicle: airplane, bicycle, boat, bus, car, motorbike, train
+- Indoor: bottle, chair, dining table, potted plant, sofa, TV/monitor
 
 I ran this on my iMac (OS X setup :ref:`here <macOS (Mac OS X)>`) with a `microAI <https://shop.luxonis.com/products/bw1093>`__ sitting on my desk pointing upwards randomly - and it makes out the corner of my iMac (which is barely visible) and correctly identifies it as `tv/monitor`:
 
@@ -87,7 +85,7 @@ To use this model, simply specify the name of the model to be run with the :code
 
   python3 depthai_demo.py -dd -cnn face-detection-retail-0004
 
-Execute the script to see an annotated video stream of face detections:
+Execute the script to see an annotated video stream of face detection:
 
 .. image:: /_static/images/tutorials/pretrained_openvino/face-2.png
   :alt: face
@@ -146,12 +144,12 @@ Let's try out :code:`face-detection-adas-0001`, which is intended for detecting 
 So this model actually has a shorter detection distance than the smaller model despite having a higher resolution.  Why?  Likely because it was intentionally trained to detect only close-in faces since it's intended to be used in the cabin of a vehicle.  (You wouldn't want to be detecting the faces in cars passing by, for example.)
 
 And also you may notice networks like emotion recognition... those networks are actually intended to be run as a second
-stage network (as they are meant to be applied only to images that contain only faces).  So to use the emotions
-recognitions network, use the command below to tell DepthAI/megaAI to run it as the second stage:
+stage network (as they are meant to be applied only to images that contain only faces).  So to use the emotion
+recognition network, use the command below to tell DepthAI/megaAI to run it as the second stage:
 
 .. code-block:: bash
 
-  ./depthai.py -cnn face-detection-retail-0004 -cnn2 emotions-recognition-retail-0003 -dd -sh 12 -cmx 12 -nce 2
+  ./depthai_demo.py -cnn face-detection-retail-0004 -cnn2 emotions-recognition-retail-0003 -dd -sh 12 -cmx 12 -nce 2
 
 .. image:: https://i.imgur.com/uqhdqJG.png
   :alt: face
@@ -165,10 +163,10 @@ as microAI is monocular only - no depth information.)
 
 So you get the **full 3D position** of the **detected object**, in this case, my face.
 
-So that the full xyz position in meters is returned.  See below.
+So that the full three-dimensional position in meters is returned.  See below.
 
-Spatial AI - Augmenting the Model with 3D Postion
-#################################################
+Spatial AI - Augmenting the Model with 3D Position
+##################################################
 
 So by default DepthAI is set to return the full 3D position.  So in the command above, we actually specify for it to not
 be calculated with :code:`-dd` (or :code:`--disable_depth`).
@@ -198,7 +196,7 @@ Monocular Neural Inference fused with Stereo Depth
 We call this mode of spatial AI 'Monocular Neural Inference fused with Stereo Depth'.  To visualize how this mode works,
 it is helpful to overlay the neural inference bounding box over the depth results directly.
 
-To visualize this, let's overlay the results directly onto the raw depth information (visualized in OpenCV HOT colormap):
+To visualize this, let's overlay the results directly onto the raw depth information (visualized in OpenCV HOT :code:`colormap`):
 
 .. code-block:: bash
 


### PR DESCRIPTION
As gen2 docs were merged (https://github.com/luxonis/depthai-docs-website/pull/148/files) some of the changes had to be migrated (like install instructions)

Also made a temporary version fix of the examples to point to `2.0.0.0`, in the next PRs I'll automate it so that on main, it always takes PyPi version, whereas on develop it takes from artifactory