### PR TITLE
depth median filter code inside the "depth preview" demo

### DIFF
--- a/docs/source/samples/03_depth_preview.rst
+++ b/docs/source/samples/03_depth_preview.rst
@@ -4,6 +4,7 @@
 This example shows how to set the SGBM (semi-global-matching) disparity-depth node, connects
 over XLink to transfer the results to the host real-time, and displays the depth map in OpenCV.
 Note that disparity is used in this case, as it colorizes in a more intuitive way.
+Below is also a preview of using different median filters side-by-side on a depth image.
 
 Demo
 ####
@@ -12,6 +13,14 @@ Demo
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
         <iframe src="https://www.youtube.com/embed/7oDjG-s-88Y" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+    </div>
+
+**Filtering depth using median filter**
+
+.. raw:: html
+
+    <div style="position: relative; padding-top: 10px;padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+        <img src="https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/images/depth-demo-filters.png" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
     </div>
 
 Setup

--- a/examples/03_depth_preview.py
+++ b/examples/03_depth_preview.py
@@ -19,6 +19,10 @@ right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 # Create a node that will produce the depth map (using disparity output as it's easier to visualize depth this way)
 depth = pipeline.createStereoDepth()
 depth.setConfidenceThreshold(200)
+# Options: MEDIAN_OFF, KERNEL_3x3, KERNEL_5x5, KERNEL_7x7 (default)
+median = dai.StereoDepthProperties.MedianFilter.KERNEL_5x5 # For depth filtering
+depth.setMedianFilter(median)
+
 left.out.link(depth.left)
 right.out.link(depth.right)
 


### PR DESCRIPTION
I added **depth median filter** code inside `03_depth_preview.py` so users can easily find it (as requested by Brandon)