### PR TITLE
fix typo in the description of example 09

### DIFF
--- a/docs/source/samples/09_mono_mobilenet.rst
+++ b/docs/source/samples/09_mono_mobilenet.rst
@@ -1,7 +1,7 @@
 09 - Mono & MobilenetSSD
 ========================
 
-This example shows how to run MobileNetv2SSD on the left grayscale camera and how to display the
+This example shows how to run MobileNetv2SSD on the right grayscale camera and how to display the
 neural network results on a preview of the right camera stream.
 
 Demo


### PR DESCRIPTION
Example uses right mono camera - fix typo in the description