### PR TITLE
Update 22_tiny_tolo_v3_decoding_on_device.rst

### DIFF
--- a/docs/source/samples/22_tiny_tolo_v3_decoding_on_device.rst
+++ b/docs/source/samples/22_tiny_tolo_v3_decoding_on_device.rst
@@ -29,7 +29,7 @@ Please run the following command to install the required dependencies
 
 For additional information, please follow :ref:`Python API installation guide <Installation - Python>`
 
-This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to work - you can download it from
+This example also requires Tiny YOLO V3 blob (:code:`tiny_yolo_v3_6shaves.blob` file) to work - you can download it from
 `here <https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/tiny-yolo-v3_openvino_2021.2_6shave.blob>`__
 
 Source code


### PR DESCRIPTION
updated to match model demo

Also link to edit page on github at 

https://docs.luxonis.com/projects/api/en/latest/samples/22_tiny_tolo_v3_decoding_on_device/ 
is broken. 

Update link to point to
https://github.com/luxonis/depthai-python/blob/main/docs/source/samples/22_tiny_tolo_v3_decoding_on_device.rst