### PR TITLE
Fix/improve AutoExposure example

### DIFF
--- a/docs/source/samples/23_autoexposure_roi.rst
+++ b/docs/source/samples/23_autoexposure_roi.rst
@@ -29,6 +29,18 @@ For additional information, please follow :ref:`Python API installation guide <I
 This example also requires MobilenetSDD blob (:code:`mobilenet.blob` file) to work - you can download it from
 `here <https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet.blob>`__
 
+Usage
+#####
+
+By default, AutoExposure region is adjusted based on neural network output. If desired, the region can be set manually.
+You can do so by pressing one of the following buttons:
+
+- `w` - move AE region up
+- `s` - move AE region down
+- `a` - move AE region left
+- `d` - move AE region right
+- `n` - deactivate manual region (switch back to nn-based roi)
+
 Source code
 ###########
 

--- a/docs/source/samples/23_autoexposure_roi.rst
+++ b/docs/source/samples/23_autoexposure_roi.rst
@@ -10,7 +10,7 @@ Demo
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-        <iframe src="https://www.youtube.com/embed/kibc8xHw8HI" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+        <iframe src="https://www.youtube.com/embed/aTqUwNL_9Bo" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
     </div>
 
 Setup

--- a/examples/23_autoexposure_roi.py
+++ b/examples/23_autoexposure_roi.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import sys
 import cv2
 import depthai as dai
-print(dai.__version__)
 import numpy as np
 
 # Press WASD to move a manual ROI window for auto-exposure control.

--- a/examples/23_autoexposure_roi.py
+++ b/examples/23_autoexposure_roi.py
@@ -21,7 +21,7 @@ cam_rgb.setInterleaved(False)
 
 xin_cam_control = pipeline.createXLinkIn()
 xin_cam_control.setStreamName('cam_control')
-xin_cam_control.out.link(cam_rgb.inputConfig)
+xin_cam_control.out.link(cam_rgb.inputControl)
 
 # Define a neural network that will make predictions based on the source frames
 detection_nn = pipeline.createNeuralNetwork()

--- a/examples/23_autoexposure_roi.py
+++ b/examples/23_autoexposure_roi.py
@@ -88,9 +88,11 @@ with dai.Device(pipeline) as device:
             bboxes = bboxes[:, 3:7]
 
             if len(bboxes) > 0 and frame is not None:
-                bbox = frame_norm(frame, bboxes[0])
+                bbox = bboxes[0]
                 ctrl = dai.CameraControl()
-                ctrl.setAutoExposureRegion(*bbox)
+                start_x, start_y = bbox[:2]
+                width, height = bbox[2] - start_x, bbox[3] - start_y
+                ctrl.setAutoExposureRegion(*frame_norm(np.empty((1920, 1080)), (start_x, start_y, width, height)))
                 q_control.send(ctrl)
 
         if frame is not None:


### PR DESCRIPTION
## Demo of the updated example:

![ezgif com-gif-maker (26)](https://user-images.githubusercontent.com/5244214/110642756-9b537880-81b3-11eb-8e7c-59be2f3deb6c.gif)


## Usage

By default, AutoExposure region is adjusted based on neural network output. If desired, the region can be set manually.
You can do so by pressing one of the following buttons:

- `w` - move AE region up
- `s` - move AE region down
- `a` - move AE region left
- `d` - move AE region right
- `n` - deactivate manual region (switch back to nn-based roi)