### PR TITLE
added code to show how to enable different depth modes

### DIFF
--- a/examples/03_depth_preview.py
+++ b/examples/03_depth_preview.py
@@ -33,11 +33,11 @@ Otherwise, depth output is U16 (mm) and median is functional.
 But like on Gen1, either depth or disparity has valid data. TODO enable both.
 '''
 # Better handling for occlusions:
-stereo.setLeftRightCheck(False)
+depth.setLeftRightCheck(False)
 # Closer-in minimum depth, disparity range is doubled:
-stereo.setExtendedDisparity(False)
+depth.setExtendedDisparity(False)
 # Better accuracy for longer distance, fractional disparity 32-levels:
-stereo.setSubpixel(False)
+depth.setSubpixel(False)
 
 left.out.link(depth.left)
 right.out.link(depth.right)

--- a/examples/03_depth_preview.py
+++ b/examples/03_depth_preview.py
@@ -20,7 +20,7 @@ right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 depth = pipeline.createStereoDepth()
 depth.setConfidenceThreshold(200)
 # Options: MEDIAN_OFF, KERNEL_3x3, KERNEL_5x5, KERNEL_7x7 (default)
-median = dai.StereoDepthProperties.MedianFilter.KERNEL_5x5 # For depth filtering
+median = dai.StereoDepthProperties.MedianFilter.KERNEL_7x7 # For depth filtering
 depth.setMedianFilter(median)
 
 '''

--- a/examples/03_depth_preview.py
+++ b/examples/03_depth_preview.py
@@ -20,8 +20,24 @@ right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 depth = pipeline.createStereoDepth()
 depth.setConfidenceThreshold(200)
 # Options: MEDIAN_OFF, KERNEL_3x3, KERNEL_5x5, KERNEL_7x7 (default)
-median = dai.StereoDepthProperties.MedianFilter.KERNEL_5x5  # For depth filtering
+median = dai.StereoDepthProperties.MedianFilter.KERNEL_5x5 # For depth filtering
 depth.setMedianFilter(median)
+
+'''
+If one or more of the additional depth modes (lrcheck, extended, subpixel)
+are enabled, then:
+ - depth output is FP16. TODO enable U16.
+ - median filtering is disabled on device. TODO enable.
+ - with subpixel, either depth or disparity has valid data.
+Otherwise, depth output is U16 (mm) and median is functional.
+But like on Gen1, either depth or disparity has valid data. TODO enable both.
+'''
+# Better handling for occlusions:
+stereo.setLeftRightCheck(False)
+# Closer-in minimum depth, disparity range is doubled:
+stereo.setExtendedDisparity(False)
+# Better accuracy for longer distance, fractional disparity 32-levels:
+stereo.setSubpixel(False)
 
 left.out.link(depth.left)
 right.out.link(depth.right)


### PR DESCRIPTION
There have been multiple questions about how to use extended depth. It would be best if we just showcase this in the depth demo.
code copied from https://github.com/luxonis/depthai-experiments/blob/master/gen2-spi/stereo-depth-crop/main.py

I set all of them to False so it wouldn't mess with the CI, not sure what are the latest FW limitations