### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,8 +91,8 @@ Now, pick a tutorial or code sample and start utilizing Gen2 capabilities
    samples/17_video_mobilenet.rst
    samples/18_rgb_encoding_mobilenet.rst
    samples/21_mobilenet_decoding_on_device.rst
-   samples/22_1_tiny_tolo_v3_decoding_on_device.rst
-   samples/22_2_tiny_tolo_v4_decoding_on_device.rst
+   samples/22_1_tiny_yolo_v3_decoding_on_device.rst
+   samples/22_2_tiny_yolo_v4_decoding_on_device.rst
    samples/23_autoexposure_roi.rst
    samples/24_opencv_support.rst
    samples/25_system_information.rst

--- a/docs/source/samples/22_1_tiny_yolo_v3_decoding_on_device.rst
+++ b/docs/source/samples/22_1_tiny_yolo_v3_decoding_on_device.rst
@@ -1,4 +1,4 @@
-21 - RGB & TinyYoloV3 decoding on device
+22.1 - RGB & TinyYoloV3 decoding on device
 ==========================================
 
 This example shows how to run TinyYoloV3 on the RGB input frame, and how to display both the RGB


### PR DESCRIPTION
fixed naming of tiny yolo demo. It wasn't shown in the docs because of this