### PR TITLE
edited checking for OS ID

### DIFF
--- a/docs/source/_static/install_dependencies.sh
+++ b/docs/source/_static/install_dependencies.sh
@@ -113,7 +113,7 @@ elif [ -f /etc/os-release ]; then
             sudo apt-get install -y "${ubuntu_arm_pkgs[@]}"
             python3 -m pip install --upgrade pip
         fi
-    elif [[ "$ID" == fedora ]]; then
+    elif [[ "$ID" == "fedora" ]]; then
         sudo dnf update -y
         sudo dnf install -y "${fedora_pkgs[@]}"
         sudo dnf groupinstall -y "Development Tools" "Development Libraries"

--- a/docs/source/_static/install_dependencies.sh
+++ b/docs/source/_static/install_dependencies.sh
@@ -103,8 +103,7 @@ elif [ -f /etc/os-release ]; then
     # shellcheck source=/etc/os-release
     source /etc/os-release
 
-    case "$ID" in
-    ubuntu|debian)
+    if [[ "$ID" == "ubuntu" || "$ID" == "debian" || "$ID_LIKE" == "ubuntu" || "$ID_LIKE" == "debian" || "$ID_LIKE" == "ubuntu debian" ]]; then
         if [[ ! $(uname -m) =~ ^arm* ]]; then
             sudo apt-get update
             sudo apt-get install -y "${ubuntu_pkgs[@]}"
@@ -114,18 +113,15 @@ elif [ -f /etc/os-release ]; then
             sudo apt-get install -y "${ubuntu_arm_pkgs[@]}"
             python3 -m pip install --upgrade pip
         fi
-        ;;
-    fedora)
+    elif [[ "$ID" == fedora ]]; then
         sudo dnf update -y
         sudo dnf install -y "${fedora_pkgs[@]}"
         sudo dnf groupinstall -y "Development Tools" "Development Libraries"
         python3 -m pip install --upgrade pip
-        ;;
-    *)
+    else
         echo "ERROR: Distribution not supported"
         exit 99
-        ;;
-    esac
+    fi
 
     # Allow all users to read and write to Myriad X devices
     echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' | sudo tee /etc/udev/rules.d/80-movidius.rules


### PR DESCRIPTION
so it now supports other ubuntu based distros (mint, pop, elementary os etc.)

Two of our users have recently had the problem that our install_dependencies.sh script returned "OS not supported" - having mint/pop OS. If we check ID_LIKE as well as ID, we can cover more ubuntu based distros