### PR TITLE
Video encoder fixes

### DIFF
--- a/src/pipeline/NodeBindings.cpp
+++ b/src/pipeline/NodeBindings.cpp
@@ -323,7 +323,7 @@ void NodeBindings::bind(pybind11::module& m){
         .def("getRateControlMode", &VideoEncoder::getRateControlMode, DOC(dai, node, VideoEncoder, getRateControlMode))
         .def("getProfile", &VideoEncoder::getProfile, DOC(dai, node, VideoEncoder, getProfile))
         .def("getBitrate", &VideoEncoder::getBitrate, DOC(dai, node, VideoEncoder, getBitrate))
-        .def("getBitrateKbps", &VideoEncoder::getBitrate, DOC(dai, node, VideoEncoder, getBitrateKbps))
+        .def("getBitrateKbps", &VideoEncoder::getBitrateKbps, DOC(dai, node, VideoEncoder, getBitrateKbps))
         .def("getKeyframeFrequency", &VideoEncoder::getKeyframeFrequency, DOC(dai, node, VideoEncoder, getKeyframeFrequency))
         //.def("getMaxBitrate", &VideoEncoder::getMaxBitrate)
         .def("getNumBFrames", &VideoEncoder::getNumBFrames, DOC(dai, node, VideoEncoder, getNumBFrames))


### PR DESCRIPTION
Binding was set to `getBitRate`
Related PR: https://github.com/luxonis/depthai-core/pull/108