### PR TITLE
bump RTD theme to fix styling issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 Sphinx==3.4.3
 sphinx-tabs==1.3.0
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==0.5.2
 git+https://github.com/VanDavv/rtd-redirects.git@3e7333898acad533b37c9de426f1f2ef258d756b
 breathe==4.26.0
 git+https://github.com/luxonis/pybind11_mkdoc.git@master


### PR DESCRIPTION
With this PR, headers are back to normal state, related PR - https://github.com/luxonis/depthai-docs-website/pull/172
![image](https://user-images.githubusercontent.com/5244214/114840917-93e94580-9dd7-11eb-9965-d1ffeb13fffd.png)
