### PR TITLE
Set frame type explicitly in Stereo host example

### DIFF
--- a/examples/09_mono_mobilenet.py
+++ b/examples/09_mono_mobilenet.py
@@ -34,7 +34,7 @@ nn.input.setBlocking(False)
 manip = pipeline.createImageManip()
 manip.initialConfig.setResize(300, 300)
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
 camRight.out.link(manip.inputImage)
 manip.out.link(nn.input)
 

--- a/examples/10_mono_depth_mobilenetssd.py
+++ b/examples/10_mono_depth_mobilenetssd.py
@@ -43,7 +43,7 @@ right.out.link(stereo.right)
 manip = pipeline.createImageManip()
 manip.initialConfig.setResize(300, 300)
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
 stereo.rectifiedRight.link(manip.inputImage)
 
 # Define a neural network that will make predictions based on the source frames

--- a/examples/11_rgb_encoding_mono_mobilenet.py
+++ b/examples/11_rgb_encoding_mono_mobilenet.py
@@ -42,7 +42,7 @@ nn.input.setBlocking(False)
 manip = pipeline.createImageManip()
 manip.initialConfig.setResize(300, 300)
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
 camRight.out.link(manip.inputImage)
 manip.out.link(nn.input)
 

--- a/examples/12_rgb_encoding_mono_mobilenet_depth.py
+++ b/examples/12_rgb_encoding_mono_mobilenet_depth.py
@@ -62,7 +62,7 @@ nn.input.setBlocking(False)
 manip = pipeline.createImageManip()
 manip.initialConfig.setResize(300, 300)
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
 depth.rectifiedRight.link(manip.inputImage)
 manip.out.link(nn.input)
 

--- a/examples/26_2_spatial_mobilenet_mono.py
+++ b/examples/26_2_spatial_mobilenet_mono.py
@@ -37,7 +37,7 @@ pipeline = dai.Pipeline()
 manip = pipeline.createImageManip()
 manip.initialConfig.setResize(300, 300)
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
 # manip.setKeepAspectRatio(False)
 
 # Define a neural network that will make predictions based on the source frames

--- a/examples/29_3_object_tracker_video.py
+++ b/examples/29_3_object_tracker_video.py
@@ -40,7 +40,7 @@ manip.initialConfig.setResizeThumbnail(384, 384)
 # manip.initialConfig.setResize(384, 384)
 # manip.initialConfig.setKeepAspectRatio(False) #squash the image to not lose FOV
 # The NN model expects BGR input. By default ImageManip output type would be same as input (gray in this case)
-manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
+manip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
 xinFrame.out.link(manip.inputImage)
 manip.inputImage.setBlocking(True)
 
@@ -123,7 +123,7 @@ with dai.Device(pipeline) as device:
             break
 
         img = dai.ImgFrame()
-        img.setType(dai.RawImgFrame.Type.BGR888p)
+        img.setType(dai.ImgFrame.Type.BGR888p)
         img.setData(to_planar(frame, inputFrameShape))
         img.setTimestamp(baseTs)
         baseTs += 1/simulatedFps

--- a/examples/30_stereo_depth_from_host.py
+++ b/examples/30_stereo_depth_from_host.py
@@ -170,7 +170,7 @@ with dai.Device(pipeline) as device:
                 img.setData(data)
                 img.setTimestamp(tstamp)
                 img.setInstanceNum(inStreamsCameraID[i])
-                img.setType(dai.RawImgFrame.Type.RAW8)
+                img.setType(dai.ImgFrame.Type.RAW8)
                 img.setWidth(1280)
                 img.setHeight(720)
                 q.send(img)

--- a/examples/30_stereo_depth_from_host.py
+++ b/examples/30_stereo_depth_from_host.py
@@ -170,6 +170,7 @@ with dai.Device(pipeline) as device:
                 img.setData(data)
                 img.setTimestamp(tstamp)
                 img.setInstanceNum(inStreamsCameraID[i])
+                img.setType(dai.RawImgFrame.Type.RAW8)
                 img.setWidth(1280)
                 img.setHeight(720)
                 q.send(img)


### PR DESCRIPTION
While this example doesn't require frame type to be set, when integrating with different nodes it may cause issues, since default frame type is set to BGR.
Explicitly setting the frame type solves integration issues.
This issue is present in [this](https://github.com/luxonis/depthai-experiments/tree/master/gen2-camera-demo) experiment too.