### PR TITLE
Allow addition of callbacks from Python code

### DIFF
--- a/src/pybind11_common.hpp
+++ b/src/pybind11_common.hpp
@@ -6,6 +6,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/functional.h>
 #include <pybind11/numpy.h>
 #include <cstdint>
 


### PR DESCRIPTION
Code used for testing:
```py
#! /usr/bin/env python

from datetime import datetime
import depthai as dai


def print_sysinfo(info):
    print("CB called")


def get_pipeline():
    # start
    p = dai.Pipeline()

    # logging
    sys_info = p.createXLinkOut()
    sys_info.setStreamName("sys_info")
    logger = p.createSystemLogger()
    logger.setRate(1)  # 1 Hz
    logger.out.link(sys_info.input)

    rgb = p.createColorCamera()
    rgb.setFps(60)
    rgb.setInterleaved(False)
    rgb.setColorOrder(dai.ColorCameraProperties.ColorOrder.BGR)
    rgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
    rgb.setPreviewSize(1920 // 3, 1080 // 3)

    roi_out = p.createXLinkOut()
    roi_out.setStreamName("roi")
    rgb.preview.link(roi_out.input)

    return p


def main():
    with dai.Device(get_pipeline()) as d:
        d.startPipeline()

        q_sysinfo = d.getOutputQueue("sys_info", 1, blocking=True)
        q_sysinfo.addCallback(print_sysinfo)
        q_cam = d.getOutputQueue("roi", 1, blocking=True)

        for count in range(1000):
            raw_img = q_cam.get()
            print(f"Frame {count}: {raw_img.getWidth()} X {raw_img.getHeight()}")


if __name__ == "__main__":
    main()
```
