### PR TITLE
Gen2 scripting - add support for external scripts

### DIFF
--- a/30_external_script_camera_control.py
+++ b/30_external_script_camera_control.py
@@ -19,15 +19,15 @@ cam = pipeline.create(dai.node.ColorCamera)
 script = pipeline.create(dai.node.Script)
 
 # no delay between captures
-embedableMethod = inspect.getsource(stillCapture)
+embeddableMethod = inspect.getsource(stillCapture)
 
 # 1 second delay between captures
-# embedableMethod = inspect.getsource(stillCaptureEverySecond)
+# embeddableMethod = inspect.getsource(stillCaptureEverySecond)
 
-embedableMethod = unindentMethod(embedableMethod)
-print(embedableMethod)
+embeddableMethod = unindentMethod(embeddableMethod)
+print(embeddableMethod)
 
-script.setScriptData(embedableMethod)
+script.setScriptData(embeddableMethod)
 
 # XLinkOut
 xout = pipeline.create(dai.node.XLinkOut)

--- a/30_external_script_camera_control.py
+++ b/30_external_script_camera_control.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import cv2
+import depthai as dai
+import numpy as np
+import time
+
+import inspect
+
+from external_script_samples import *
+from external_script_utils import *
+
+# Start defining a pipeline
+pipeline = dai.Pipeline()
+
+# Define a source - color camera
+cam = pipeline.create(dai.node.ColorCamera)
+
+# Script node
+script = pipeline.create(dai.node.Script)
+
+# no delay between captures
+embedableMethod = inspect.getsource(stillCapture)
+
+# 1 second delay between captures
+# embedableMethod = inspect.getsource(stillCaptureEverySecond)
+
+embedableMethod = unindentMethod(embedableMethod)
+print(embedableMethod)
+
+script.setScriptData(embedableMethod)
+
+# XLinkOut
+xout = pipeline.create(dai.node.XLinkOut)
+xout.setStreamName('still')
+
+# Connections
+script.outputs['out'].link(cam.inputControl)
+cam.still.link(xout.input)
+
+# Connect to device and start pipeline
+with dai.Device(pipeline) as device:
+    # Start pipeline
+    device.startPipeline()
+    while True:
+        img = device.getOutputQueue("still").get()
+        cv2.imshow('still', img.getCvFrame())
+        if cv2.waitKey(1) == ord('q'):
+            exit(0)

--- a/external_script_samples.py
+++ b/external_script_samples.py
@@ -1,0 +1,15 @@
+from depthai import CameraControl
+
+def stillCapture():
+    ctrl = CameraControl()
+    ctrl.setCaptureStill(True)
+    while True:
+        node.io['out'].send(ctrl)
+
+def stillCaptureEverySecond():
+    import time
+    ctrl = CameraControl()
+    ctrl.setCaptureStill(True)
+    while True:
+        time.sleep(1)
+        node.io['out'].send(ctrl)

--- a/external_script_utils.py
+++ b/external_script_utils.py
@@ -1,0 +1,7 @@
+def unindentMethod(methodString):
+    lines = methodString.split('\n')
+    methodString = ''
+    for line in lines:
+        if len(line)>4 and line[0:3] != 'def':
+            methodString+=line[4:]+'\n'
+    return(methodString)


### PR DESCRIPTION
Using Python inspect module we can define multiple scripts in one file and parse them and inject them individually

Would be nice to be able to write methods and use them as is, instead of current approach.

Imports must be included in the methods, see stillCaptureEverySecond example in external_script_samples.py