### PR TITLE
Updated READMEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,9 +158,27 @@ target_link_libraries(${TARGET_NAME}
         hedley
 )
 
-# Add default commit hash ('dev') if not build by CI
+# Add local commit hash (or 'dev' if unable to retrieve) if not build by CI
 if(NOT DEFINED ENV{CI} AND NOT DEPTHAI_PYTHON_COMMIT_HASH)
-    set(DEPTHAI_PYTHON_COMMIT_HASH "dev")
+    set(BUILD_COMMIT "dev")
+    find_package(Git)
+    if(GIT_FOUND)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE BUILD_COMMIT
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} show -s --format=%ci ${BUILD_COMMIT}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        OUTPUT_VARIABLE BUILD_COMMIT_DATETIME
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(DEPTHAI_PYTHON_COMMIT_HASH ${BUILD_COMMIT})
 endif()
 
 # Get version to use
@@ -174,8 +192,15 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} "-c" "${version_command}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
-# Add version definition
-target_compile_definitions(${TARGET_NAME} PRIVATE DEPTHAI_PYTHON_VERSION="${DEPTHAI_PYTHON_VERSION}")
+# Add build information
+string(TIMESTAMP BUILD_DATETIME "%Y-%m-%d %H:%M:%S +0000" UTC)
+target_compile_definitions(${TARGET_NAME}
+    PRIVATE
+        DEPTHAI_PYTHON_VERSION="${DEPTHAI_PYTHON_VERSION}"
+        DEPTHAI_PYTHON_COMMIT_HASH="${DEPTHAI_PYTHON_COMMIT_HASH}"
+        DEPTHAI_PYTHON_COMMIT_DATETIME="${BUILD_COMMIT_DATETIME}"
+        DEPTHAI_PYTHON_BUILD_DATETIME="${BUILD_DATETIME}"
+)
 
 # Set compiler features (c++14), and disables extensions
 set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 14)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python3 -m pip install --extra-index-url https://artifacts.luxonis.com/artifacto
 ### Dependencies
  - cmake >= 3.4
  - C++14 compiler (clang, gcc, msvc, ...)
- - Python
+ - Python3
 
 Along these, dependencies of depthai-core are also required
 See: [depthai-core dependencies](https://github.com/luxonis/depthai-core#dependencies)
@@ -31,38 +31,51 @@ See: [depthai-core dependencies](https://github.com/luxonis/depthai-core#depende
 
 ### Building
 
-To build a shared library from source perform the following:
+To build and install using pip:
 ```
-git submodule update --init --recursive
-mkdir build && cd build
-cmake .. [-D PYTHON_EXECUTABLE=/full/path/to/python]
-cmake --build . --parallel
+python3 -m pip install .
 ```
-Where `-D PYTHON_EXECUTABLE` option can optionally specify an exact Python executable to use for building.
+Add parameter `-v` to see the output of the building process.
 
-ℹ️ For the `--parallel` argument, specify a value `[num CPU cores]` or less, to reduce memory consumption during build. E.g.: `--parallel 8`
 
 To build a wheel, execute the following
 ```
 python3 -m pip wheel . -w wheelhouse
 ```
 
-To build and install using pip:
+To build a shared library from source perform the following:
+
+> ℹ️ To speed up build times, use `cmake --build build --parallel [num CPU cores]` (CMake >= 3.12).
+For older versions use: Linux/macOS: `cmake --build build -- -j[num CPU cores]`, MSVC: `cmake --build build -- /MP[num CPU cores]`
+
 ```
-python3 -m pip install .
+git submodule update --init --recursive
+cmake -H. -Bbuild
+cmake --build build
 ```
+To specify custom Python executable to build for, use `cmake -H. -Bbuild -D PYTHON_EXECUTABLE=/full/path/to/python`.
+
 
 ## Running tests
 
 To run the tests build the library with the following options
 ```
 git submodule update --init --recursive
-mkdir build_tests && cd build_tests
-cmake .. -D DEPTHAI_PYTHON_ENABLE_TESTS=ON -D DEPTHAI_PYTHON_ENABLE_EXAMPLES=ON -D DEPTHAI_PYTHON_TEST_EXAMPLES=ON
-cmake --build . --parallel
+cmake -H. -Bbuild -D DEPTHAI_PYTHON_ENABLE_TESTS=ON -D DEPTHAI_PYTHON_ENABLE_EXAMPLES=ON -D DEPTHAI_PYTHON_TEST_EXAMPLES=ON
+cmake --build build
+```
+
+Then navigate to `build` folder and run `ctest`
+```
+cd build
 ctest
 ```
 
+To test a specific example/test with a custom timeout (in seconds) use following:
+```
+TEST_TIMEOUT=0 ctest -R "01_rgb_preview" --verbose
+```
+If `TEST_TIMEOUT=0`, the test will run until stopped or it ends.
 
 ## Tested platforms
 
@@ -95,8 +108,8 @@ ctest
      ```
      python3 -m pip install -U pip
      python3 -m pip install -r docs/requirements.txt
-     cmake -S . -B build -D DEPTHAI_BUILD_DOCS=ON -D DEPTHAI_PYTHON_BUILD_DOCS=ON
-     cmake --build build --parallel --target sphinx
+     cmake -H. -Bbuild -D DEPTHAI_BUILD_DOCS=ON -D DEPTHAI_PYTHON_BUILD_DOCS=ON
+     cmake --build build --target sphinx
      python3 -m http.server --bind 0.0.0.0 8000 --directory build/docs/sphinx
      ```
 
@@ -106,7 +119,7 @@ ctest
      in a new terminal window to update the website source
 
      ```
-     cmake --build build --parallel --target sphinx
+     cmake --build build --target sphinx
      ```
 
      Then refresh your page - it should load the updated website that was just built

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -55,6 +55,12 @@ extensions = [
 # See https://github.com/sphinx-doc/sphinx/issues/7728
 suppress_warnings = ['autosectionlabel.*']
 
+# # Debug docstrings
+# def autodoc_process_docstring(app, what, name, obj, options, lines):
+#     print('process: ', what, name, obj, options, lines)
+# def setup(app):
+#     app.connect("autodoc-process-docstring", autodoc_process_docstring)
+
 # substitutions
 rst_prolog = '.. |release| replace:: ' + release
 

--- a/docs/source/references/python.rst
+++ b/docs/source/references/python.rst
@@ -5,6 +5,6 @@ Python API Reference
 .. automodule:: depthai
     :autosummary:
     :members:
-    :special-members: __init__  
+    :special-members: __init__
     :show-inheritance:
     :undoc-members:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,122 +1,13 @@
-# Depthai-Python examples
+# Examples
 
-In this directory there are usage examples of depthai-python repository. 
+In this directory there are usage examples of DepthAI Python library.
+
+## Description
+
+More details about examples can be found at [Luxonis DepthAI API - Code Samples](https://docs.luxonis.com/projects/api/en/latest/tutorials/code_samples/)
 
 ## Setup
 
-Navigate to root of repository and build Python module with DEPTHAI_PYTHON_TEST_EXAMPLES option enabled
-
 ```
-mkdir -p build && cd build
-cmake .. -DDEPTHAI_PYTHON_ENABLE_EXAMPLES=ON
-cmake --build . --parallel
+python3 install_dependencies.py
 ```
-ℹ️ For the `--parallel` argument above, specify a value `[num CPU cores]` or less, to reduce memory consumption during build. E.g.: `--parallel 8`
-
-If you'd like to use a different Python interpreter, set `PYTHON_EXECUTABLE` to your interpreter location
-
-```
-cmake .. -DDEPTHAI_PYTHON_ENABLE_EXAMPLES=ON -D PYTHON_EXECUTABLE=/path/to/python
-```
-
-## Usage
-
-To test all examples
-```
-ctest
-```
-
-To execute a specific example (without timeout)
-```
-TEST_TIMEOUT=0 ctest -R "01_rgb_preview" --verbose
-```
-
-## Demo
-
-### 01_rgb_preview.py
-![example_1](https://user-images.githubusercontent.com/5244214/104040973-9afd2800-51d8-11eb-8fe6-52649069ded5.gif)
-
-### 02_mono_preview.py
-![example_2](https://user-images.githubusercontent.com/5244214/104040960-959fdd80-51d8-11eb-8bde-fd706b5c8670.gif)
-
-### 03_depth_preview.py
-
-**NOTE** For clearness, a `disparity` output is used instead of `depth`, as disparity is better to visualize
-
-![example_3](https://user-images.githubusercontent.com/5244214/104055993-fdadee00-51ef-11eb-9c52-882e1b0e734b.gif)
-
-### 04_rgb_encoding.py
-![example_4](https://user-images.githubusercontent.com/5244214/104040930-8f116600-51d8-11eb-888a-88272c34aed4.gif)
-
-### 05_rgb_mono_encoding.py
-![example_5](https://user-images.githubusercontent.com/5244214/104040921-8d47a280-51d8-11eb-9bc1-d809ec6cd9f6.gif)
-
-### 06_rgb_full_resolution_saver.py
-![example_6](https://user-images.githubusercontent.com/5244214/104040908-8882ee80-51d8-11eb-8817-1c8dca320f2b.gif)
-
-### 07_mono_full_resolution_saver.py
-![example_7](https://user-images.githubusercontent.com/5244214/104040905-86209480-51d8-11eb-9e15-5fe94aba7b69.gif)
-
-### 08_rgb_mobilenet.py
-![example_8](https://user-images.githubusercontent.com/5244214/112838840-cb4cb800-909d-11eb-8264-83d3c1e5f348.gif)
-
-### 09_mono_mobilenet.py
-![example_9](https://user-images.githubusercontent.com/5244214/112838832-ca1b8b00-909d-11eb-8ea1-eafeb98c3266.gif)
-
-### 10_mono_depth_mobilenetssd.py
-
-**NOTE** For clearness, a `disparity` output is used instead of `depth`, as disparity is better to visualize
-
-![example_10](https://user-images.githubusercontent.com/5244214/112838828-c8ea5e00-909d-11eb-912a-ce3995a68bfd.gif)
-
-### 11_rgb_encoding_mono_mobilenet.py
-![example_11](https://user-images.githubusercontent.com/5244214/112838821-c851c780-909d-11eb-86d4-d7a6b6d0aebe.gif)
-
-### 12_rgb_encoding_mono_mobilenet_depth.py
-
-**NOTE** For clearness, a `disparity` output is used instead of `depth`, as disparity is better to visualize
-
-![example_12](https://user-images.githubusercontent.com/5244214/112838818-c7209a80-909d-11eb-8f50-81c023c59e9b.gif)
-
-### 13_encoding_max_limit.py
-![example_13](https://user-images.githubusercontent.com/5244214/104741072-0307bd00-5749-11eb-97f3-9422c8b0d8da.gif)
-
-### 14_color_camera_control.py
-![example_14](https://user-images.githubusercontent.com/5244214/104741150-187ce700-5749-11eb-8bd5-3d4f37d2d22a.gif)
-
-### 15_rgb_mobilenet_4k.py
-![15](https://user-images.githubusercontent.com/5244214/112838812-c556d700-909d-11eb-8194-83602530c9af.gif)
-
-### 16_device_queue_event.py
-![16](https://user-images.githubusercontent.com/5244214/112838810-c425aa00-909d-11eb-9962-550533f13268.gif)
-
-### 17_video_mobilenet.py
-![17](https://user-images.githubusercontent.com/5244214/112838807-c38d1380-909d-11eb-9c89-878eaa20e4ed.gif)
-
-### 18_rgb_encoding_mobilenet.py
-![18](https://user-images.githubusercontent.com/5244214/112838805-c25be680-909d-11eb-8db2-2d0ce61aebe0.gif)
-
-### 22_1_tiny_yolo_v3_device_side_decoding.py
-![22_1](https://user-images.githubusercontent.com/5244214/112838798-c12ab980-909d-11eb-8e6c-5aa3d623c7e9.gif)
-
-### 22_2_tiny_yolo_v4_device_side_decoding.py
-![22_2](https://user-images.githubusercontent.com/5244214/112838790-bff98c80-909d-11eb-8b85-7c4dbd9a0e62.gif)
-
-### 23_autoexposure_roi.py
-![23](https://user-images.githubusercontent.com/5244214/112838784-be2fc900-909d-11eb-8067-291636ae9950.gif)
-
-### 24_opencv_support.py
-![24](https://user-images.githubusercontent.com/5244214/112838789-bf60f600-909d-11eb-9fb5-203dbec774f8.gif)
-
-### 26_1_spatial_mobilenet.py
-![26_1](https://user-images.githubusercontent.com/5244214/112838781-bcfe9c00-909d-11eb-9d12-a9834f545271.gif)
-
-### 26_2_spatial_mobilenet_mono.py
-![26_2](https://user-images.githubusercontent.com/5244214/112838777-bbcd6f00-909d-11eb-9b1e-d93159c3d88f.gif)
-
-### 26_3_spatial_tiny_yolo.py
-![26_3](https://user-images.githubusercontent.com/5244214/112838772-ba9c4200-909d-11eb-9678-0703df46b529.gif)
-
-### 28_camera_video_example.py
-![28](https://user-images.githubusercontent.com/5244214/112838767-b8d27e80-909d-11eb-92f0-5af20c4326b7.gif)
-

--- a/src/py_bindings.cpp
+++ b/src/py_bindings.cpp
@@ -33,8 +33,12 @@ PYBIND11_MODULE(depthai,m)
 
     // Depthai python version consists of: (depthai-core).(bindings revision)[+bindings hash]
     m.attr("__version__") = DEPTHAI_PYTHON_VERSION;
+    m.attr("__commit__") = DEPTHAI_PYTHON_COMMIT_HASH;
+    m.attr("__commit_datetime__") = DEPTHAI_PYTHON_COMMIT_DATETIME;
+    m.attr("__build_datetime__") = DEPTHAI_PYTHON_BUILD_DATETIME;
 
-    // Add bindings 
+
+    // Add bindings
     OpenVINOBindings::bind(m);
     AssetManagerBindings::bind(m);
     NodeBindings::bind(m);
@@ -47,8 +51,8 @@ PYBIND11_MODULE(depthai,m)
     DataQueueBindings::bind(m);
     LogBindings::bind(m);
 
-    // Call dai::initialize on 'import depthai' to initialize asap
-    dai::initialize();
+    // Call dai::initialize on 'import depthai' to initialize asap with additional information to print
+    dai::initialize(std::string("Python bindings - version: ") + DEPTHAI_PYTHON_VERSION + " from " + DEPTHAI_PYTHON_COMMIT_DATETIME + " build: " + DEPTHAI_PYTHON_BUILD_DATETIME);
 
 }
 


### PR DESCRIPTION
Moved around documentation on local building / installation to prefer installation using `pip` compared to `CMake`.
Simplified examples/README.md to point to documentation website instead. 

EDIT:
Added additional improvements and fixes. 
 - Populated modules fields along `__version__`: `__commit__`, `__commit_datetime__`, `__build_datetime__`
 - Added print of these to module initialization:
    ```
    [2021-05-03 02:16:16.000] [debug] Python bindings - version: 2.2.1.0.dev+03bf4cfe62691b86d083ac557faf3509324691d3 from 2021-05-02 23:14:15 +0200 build: 2021-05-02 23:40:48 +0000
    ```
 - Resolved docs building issues
