### PR TITLE
Explanation of depth modes in stereoDepth node docs

### DIFF
--- a/docs/source/components/nodes/stereo_depth.rst
+++ b/docs/source/components/nodes/stereo_depth.rst
@@ -74,6 +74,42 @@ If one or more of the additional depth modes (:code:`lrcheck`, :code:`extended`,
 
 Otherwise, :code:`depth` output is **U16** (in millimeters) and median is functional.
 
+Depth Modes
+###########
+
+Left-Right Check
+****************
+
+Left-Right Check, or LR-Check is used to remove incorrectly calculated disparity pixels due to occlusions at object borders (Left and Right camera views
+are slightly different).
+
+#. Computes disparity by matching in R->L direction
+#. Computes disparity by matching in L->R direction
+#. Combines results from 1 and 2, running on Shave: each pixel d = disparity_LR(x,y) is compared with disparity_RL(x-d,y). If the difference is above a threshold, the pixel at (x,y) in final disparity map is invalidated.
+
+Extended Disparity
+******************
+
+The :code:`extended disparity` allows detecting closer distance objects for the given baseline. This increases the maximum disparity search from 96 to 191.
+So this cuts the minimum perceivable distance in half, given that the minimum distance is now :code:`focal_length * base_line_dist / 191` instead
+of :code:`focal_length * base_line_dist / 96`.
+
+#. Computes disparity on the original size images (e.g. 1280x720)
+#. Computes disparity on 2x downscaled images (e.g. 640x360)
+#. Combines the two level disparities on Shave, effectively covering a total disparity range of 191 pixels (in relation to the original resolution).
+
+Subpixel Disparity
+******************
+
+Subpixel improves the precision and is especially useful for long range measurements. It also helps for better estimating surface normals
+
+Beside the integer disparity output, the Stereo engine is programmed to dump to memory the cost volume, that is 96 levels (disparities) per pixel,
+then software interpolation is done on Shave, resulting a final disparity with 5 fractional bits, resulting in significantly more granual depth
+steps (32 additional steps between the integer-pixel depth steps), and also theoretically, longer-distance depth viewing - as the maximum depth
+is no longer limited by a feature being a full integer pixel-step apart, but rather 1/32 of a pixel.
+
+For comparison of normal disparity vs. subpixel disparity images, click `here <https://github.com/luxonis/depthai/issues/184>`__.
+
 Usage
 #####
 

--- a/docs/source/components/nodes/stereo_depth.rst
+++ b/docs/source/components/nodes/stereo_depth.rst
@@ -80,19 +80,19 @@ Depth Modes
 Left-Right Check
 ****************
 
-Left-Right Check, or LR-Check is used to remove incorrectly calculated disparity pixels due to occlusions at object borders (Left and Right camera views
+Left-Right Check or LR-Check is used to remove incorrectly calculated disparity pixels due to occlusions at object borders (Left and Right camera views
 are slightly different).
 
 #. Computes disparity by matching in R->L direction
 #. Computes disparity by matching in L->R direction
-#. Combines results from 1 and 2, running on Shave: each pixel d = disparity_LR(x,y) is compared with disparity_RL(x-d,y). If the difference is above a threshold, the pixel at (x,y) in final disparity map is invalidated.
+#. Combines results from 1 and 2, running on Shave: each pixel d = disparity_LR(x,y) is compared with disparity_RL(x-d,y). If the difference is above a threshold, the pixel at (x,y) in the final disparity map is invalidated.
 
 Extended Disparity
 ******************
 
 The :code:`extended disparity` allows detecting closer distance objects for the given baseline. This increases the maximum disparity search from 96 to 191.
-So this cuts the minimum perceivable distance in half, given that the minimum distance is now :code:`focal_length * base_line_dist / 191` instead
-of :code:`focal_length * base_line_dist / 96`.
+So this cuts the minimum perceivable distance in half, given that the minimum distance is now :code:`focal_length * base_line_dist / 190` instead
+of :code:`focal_length * base_line_dist / 95`.
 
 #. Computes disparity on the original size images (e.g. 1280x720)
 #. Computes disparity on 2x downscaled images (e.g. 640x360)
@@ -103,8 +103,8 @@ Subpixel Disparity
 
 Subpixel improves the precision and is especially useful for long range measurements. It also helps for better estimating surface normals
 
-Beside the integer disparity output, the Stereo engine is programmed to dump to memory the cost volume, that is 96 levels (disparities) per pixel,
-then software interpolation is done on Shave, resulting a final disparity with 5 fractional bits, resulting in significantly more granual depth
+Besides the integer disparity output, the Stereo engine is programmed to dump to memory the cost volume, that is 96 levels (disparities) per pixel,
+then software interpolation is done on Shave, resulting a final disparity with 5 fractional bits, resulting in significantly more granular depth
 steps (32 additional steps between the integer-pixel depth steps), and also theoretically, longer-distance depth viewing - as the maximum depth
 is no longer limited by a feature being a full integer pixel-step apart, but rather 1/32 of a pixel.
 


### PR DESCRIPTION
Text was copied from the FAQ docs.

This is how it looks:
![image](https://user-images.githubusercontent.com/18037362/118493009-8dbcf080-b718-11eb-9f47-a33bbda714da.png)
