### PR TITLE
rgb_depth_aligned: lower Mono resolution 720p -> 400p, to reduce lag

### DIFF
--- a/examples/rgb_depth_aligned.py
+++ b/examples/rgb_depth_aligned.py
@@ -7,6 +7,9 @@ import depthai as dai
 # Optional. If set (True), the ColorCamera is downscaled from 1080p to 720p.
 # Otherwise (False), the aligned depth is automatically upscaled to 1080p
 downscaleColor = True
+fps = 30
+# The disparity is computed at this resolution, then upscaled to RGB resolution
+monoResolution = dai.MonoCameraProperties.SensorResolution.THE_400_P
 
 # Create pipeline
 pipeline = dai.Pipeline()
@@ -29,17 +32,20 @@ queueNames.append("depth")
 #Properties
 camRgb.setBoardSocket(dai.CameraBoardSocket.RGB)
 camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
+camRgb.setFps(fps)
 if downscaleColor: camRgb.setIspScale(2, 3)
 # For now, RGB needs fixed focus to properly align with depth.
 # This value was used during calibration
 camRgb.initialControl.setManualFocus(130)
 
-left.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+left.setResolution(monoResolution)
 left.setBoardSocket(dai.CameraBoardSocket.LEFT)
-right.setResolution(dai.MonoCameraProperties.SensorResolution.THE_720_P)
+left.setFps(fps)
+right.setResolution(monoResolution)
 right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
+right.setFps(fps)
 
-stereo.setConfidenceThreshold(200)
+stereo.setConfidenceThreshold(230)
 # LR-check is required for depth alignment
 stereo.setLeftRightCheck(True)
 stereo.setDepthAlign(dai.CameraBoardSocket.RGB)


### PR DESCRIPTION
The resulting disparity/depth is still upscaled to the configured RGB resolution.
Workaround until the disparity centering implementation is further optimized, to be able to run at 720p 30fps.