### PR TITLE
Close queues when closing the device

### DIFF
--- a/src/DataQueueBindings.cpp
+++ b/src/DataQueueBindings.cpp
@@ -31,6 +31,8 @@ void DataQueueBindings::bind(pybind11::module& m){
     };
     py::class_<DataOutputQueue, std::shared_ptr<DataOutputQueue>>(m, "DataOutputQueue", DOC(dai, DataOutputQueue))
         .def("getName", &DataOutputQueue::getName, DOC(dai, DataOutputQueue, getName))
+        .def("isClosed", &DataOutputQueue::isClosed, DOC(dai, DataOutputQueue, isClosed))
+        .def("close", &DataOutputQueue::close, DOC(dai, DataOutputQueue, close))
 
         .def("addCallback", addCallbackLambda, py::arg("callback"), DOC(dai, DataOutputQueue, addCallback))
         .def("addCallback", addCallbackLambda, py::arg("callback"), DOC(dai, DataOutputQueue, addCallback, 2))
@@ -92,6 +94,8 @@ void DataQueueBindings::bind(pybind11::module& m){
 
     // Bind DataInputQueue
     py::class_<DataInputQueue, std::shared_ptr<DataInputQueue>>(m, "DataInputQueue", DOC(dai, DataInputQueue))
+        .def("isClosed", &DataInputQueue::isClosed, DOC(dai, DataInputQueue, isClosed))
+        .def("close", &DataInputQueue::close, DOC(dai, DataInputQueue, close))
         .def("getName", &DataInputQueue::getName, DOC(dai, DataInputQueue, getName))
         .def("setBlocking", &DataInputQueue::setBlocking, py::arg("blocking"), DOC(dai, DataInputQueue, setBlocking))
         .def("getBlocking", &DataInputQueue::getBlocking, DOC(dai, DataInputQueue, getBlocking))


### PR DESCRIPTION
Modified close behavior of Device. Existing queues are closed alongside and don't rely solely on destructor to close them.

Potentialy closes: #296 