### PR TITLE
Two stage binding

### DIFF
--- a/src/CalibrationHandlerBindings.cpp
+++ b/src/CalibrationHandlerBindings.cpp
@@ -3,12 +3,27 @@
 #include "depthai-shared/common/Point2f.hpp"
 #include <vector>
 
-void CalibrationHandlerBindings::bind(pybind11::module& m){
+void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
-    // bind pipeline
-    py::class_<CalibrationHandler>(m, "CalibrationHandler", DOC(dai, CalibrationHandler))
+    // Type definitions
+    py::class_<CalibrationHandler> calibrationHandler(m, "CalibrationHandler", DOC(dai, CalibrationHandler));
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+    // Bindings
+    calibrationHandler
         .def(py::init<>(), DOC(dai, CalibrationHandler, CalibrationHandler))
         .def(py::init<std::string>(), DOC(dai, CalibrationHandler, CalibrationHandler, 2))
         .def(py::init<std::string, std::string>(), DOC(dai, CalibrationHandler, CalibrationHandler, 3))

--- a/src/CalibrationHandlerBindings.hpp
+++ b/src/CalibrationHandlerBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct CalibrationHandlerBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/DataQueueBindings.cpp
+++ b/src/DataQueueBindings.cpp
@@ -6,10 +6,29 @@
 // depthai
 #include "depthai/device/DataQueue.hpp"
 
-void DataQueueBindings::bind(pybind11::module& m){
-
+void DataQueueBindings::bind(pybind11::module& m, void* pCallstack){
     using namespace dai;
     using namespace std::chrono;
+
+
+    // Type definitions
+    py::class_<DataOutputQueue, std::shared_ptr<DataOutputQueue>> dataOutputQueue(m, "DataOutputQueue", DOC(dai, DataOutputQueue));
+    py::class_<DataInputQueue, std::shared_ptr<DataInputQueue>> dataInputQueue(m, "DataInputQueue", DOC(dai, DataInputQueue));
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
 
     // To prevent blocking whole python interpreter, blocking functions like 'get' and 'send'
     // are pooled with a reasonable delay and check for python interrupt signal in between.
@@ -29,7 +48,7 @@ void DataQueueBindings::bind(pybind11::module& m){
             throw py::value_error("Callback must take either zero, one or two arguments");
         }
     };
-    py::class_<DataOutputQueue, std::shared_ptr<DataOutputQueue>>(m, "DataOutputQueue", DOC(dai, DataOutputQueue))
+    dataOutputQueue
         .def("getName", &DataOutputQueue::getName, DOC(dai, DataOutputQueue, getName))
         .def("isClosed", &DataOutputQueue::isClosed, DOC(dai, DataOutputQueue, isClosed))
         .def("close", &DataOutputQueue::close, DOC(dai, DataOutputQueue, close))
@@ -93,7 +112,7 @@ void DataQueueBindings::bind(pybind11::module& m){
         ;
 
     // Bind DataInputQueue
-    py::class_<DataInputQueue, std::shared_ptr<DataInputQueue>>(m, "DataInputQueue", DOC(dai, DataInputQueue))
+    dataInputQueue
         .def("isClosed", &DataInputQueue::isClosed, DOC(dai, DataInputQueue, isClosed))
         .def("close", &DataInputQueue::close, DOC(dai, DataInputQueue, close))
         .def("getName", &DataInputQueue::getName, DOC(dai, DataInputQueue, getName))

--- a/src/DataQueueBindings.hpp
+++ b/src/DataQueueBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct DataQueueBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -44,13 +44,86 @@
 
 // #include "spdlog/spdlog.h"
 
-void DatatypeBindings::bind(pybind11::module& m){
+void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
 
 
     using namespace dai;
 
-    // Bind Raw datatypes
-    py::class_<RawBuffer, std::shared_ptr<RawBuffer>>(m, "RawBuffer", DOC(dai, RawBuffer))
+    py::class_<RawBuffer, std::shared_ptr<RawBuffer>> rawBuffer(m, "RawBuffer", DOC(dai, RawBuffer));
+    py::class_<RawImgFrame, RawBuffer, std::shared_ptr<RawImgFrame>> rawImgFrame(m, "RawImgFrame", DOC(dai, RawImgFrame));
+    py::enum_<RawImgFrame::Type> rawImgFrameType(rawImgFrame, "Type");
+    py::class_<RawImgFrame::Specs> rawImgFrameSpecs(rawImgFrame, "Specs", DOC(dai, RawImgFrame, Specs));
+    py::class_<RawNNData, RawBuffer, std::shared_ptr<RawNNData>> rawNnData(m, "RawNNData", DOC(dai, RawNNData));
+    py::class_<TensorInfo> tensorInfo(m, "TensorInfo", DOC(dai, TensorInfo));
+    py::enum_<TensorInfo::DataType>tensorInfoDataType(tensorInfo, "DataType");
+    py::enum_<TensorInfo::StorageOrder>tensorInfoStorageOrder(tensorInfo, "StorageOrder");
+    py::class_<ImgDetection> imgDetection(m, "ImgDetection", DOC(dai, ImgDetection));
+    py::class_<SpatialImgDetection, ImgDetection> spatialImgDetection(m, "SpatialImgDetection", DOC(dai, SpatialImgDetection));
+    py::class_<RawImgDetections, RawBuffer, std::shared_ptr<RawImgDetections>> rawImgDetections(m, "RawImgDetections", DOC(dai, RawImgDetections));
+    py::class_<RawSpatialImgDetections, RawBuffer, std::shared_ptr<RawSpatialImgDetections>> rawSpatialImgDetections(m, "RawSpatialImgDetections", DOC(dai, RawSpatialImgDetections));
+    py::class_<RawImageManipConfig, RawBuffer, std::shared_ptr<RawImageManipConfig>> rawImageManipConfig(m, "RawImageManipConfig", DOC(dai, RawImageManipConfig));
+    py::class_<RawImageManipConfig::CropRect> rawImageManipConfigCropRect(rawImageManipConfig, "CropRect", DOC(dai, RawImageManipConfig, CropRect));
+    py::class_<RawImageManipConfig::CropConfig> rawImageManipCropConfig(rawImageManipConfig, "CropConfig", DOC(dai, RawImageManipConfig, CropConfig));
+    py::class_<RawImageManipConfig::ResizeConfig>rawImageManipConfigResizeConfig(rawImageManipConfig, "ResizeConfig", DOC(dai, RawImageManipConfig, ResizeConfig));
+    py::class_<RawImageManipConfig::FormatConfig> rawImageManipConfigFormatConfig(rawImageManipConfig, "FormatConfig", DOC(dai, RawImageManipConfig, FormatConfig));
+    py::class_<RawCameraControl, RawBuffer, std::shared_ptr<RawCameraControl>> rawCameraControl(m, "RawCameraControl", DOC(dai, RawCameraControl));
+    py::class_<Tracklet> tracklet(m, "Tracklet", DOC(dai, Tracklet));
+    py::enum_<Tracklet::TrackingStatus> trackletTrackingStatus(tracklet, "TrackingStatus", DOC(dai, Tracklet, TrackingStatus));
+    py::class_<RawTracklets, RawBuffer, std::shared_ptr<RawTracklets>> rawTacklets(m, "RawTracklets", DOC(dai, RawTracklets));
+    py::class_<IMUReport, std::shared_ptr<IMUReport>> imuReport(m, "IMUReport", DOC(dai, IMUReport));
+    py::enum_<IMUReport::Accuracy> imuReportAccuracy(imuReport, "Accuracy");
+    py::class_<IMUReportAccelerometer, IMUReport, std::shared_ptr<IMUReportAccelerometer>> imuReportAccelerometer(m, "IMUReportAccelerometer", DOC(dai, IMUReportAccelerometer));
+    py::class_<IMUReportGyroscope, IMUReport, std::shared_ptr<IMUReportGyroscope>> imuReportGyroscope(m, "IMUReportGyroscope", DOC(dai, IMUReportGyroscope));
+    py::class_<IMUReportMagneticField, IMUReport, std::shared_ptr<IMUReportMagneticField>> imuReportMagneticField(m, "IMUReportMagneticField", DOC(dai, IMUReportMagneticField));
+    py::class_<IMUReportRotationVectorWAcc, IMUReport, std::shared_ptr<IMUReportRotationVectorWAcc>> imuReportRotationVectorWAcc(m, "IMUReportRotationVectorWAcc", DOC(dai, IMUReportRotationVectorWAcc));
+    py::class_<IMUPacket> imuPacket(m, "IMUPacket", DOC(dai, IMUPacket));
+    py::class_<RawIMUData, RawBuffer, std::shared_ptr<RawIMUData>> rawIMUPackets(m, "RawIMUData", DOC(dai, RawIMUData));
+    py::enum_<RawCameraControl::AutoFocusMode> rawCameraControlAutoFocusMode(rawCameraControl, "AutoFocusMode", DOC(dai, RawCameraControl, AutoFocusMode));
+    py::enum_<RawCameraControl::AutoWhiteBalanceMode> rawCameraControlAutoWhiteBalanceMode(rawCameraControl, "AutoWhiteBalanceMode", DOC(dai, RawCameraControl, AutoWhiteBalanceMode));
+    py::enum_<RawCameraControl::SceneMode> rawCameraControlSceneMode(rawCameraControl, "SceneMode", DOC(dai, RawCameraControl, SceneMode));
+    py::enum_<RawCameraControl::AntiBandingMode> rawCameraControlAntiBandingMode(rawCameraControl, "AntiBandingMode", DOC(dai, RawCameraControl, AntiBandingMode));
+    py::enum_<RawCameraControl::EffectMode> rawCameraControlEffectMode(rawCameraControl, "EffectMode", DOC(dai, RawCameraControl, EffectMode));
+    py::class_<RawSystemInformation, RawBuffer, std::shared_ptr<RawSystemInformation>> rawSystemInformation(m, "RawSystemInformation", DOC(dai, RawSystemInformation));
+    py::class_<ADatatype, std::shared_ptr<ADatatype>> adatatype(m, "ADatatype", DOC(dai, ADatatype));
+    py::class_<Buffer, ADatatype, std::shared_ptr<Buffer>> buffer(m, "Buffer", DOC(dai, Buffer));
+    py::class_<ImgFrame, Buffer, std::shared_ptr<ImgFrame>> imgFrame(m, "ImgFrame", DOC(dai, ImgFrame));
+    py::class_<RotatedRect> rotatedRect(m, "RotatedRect", DOC(dai, RotatedRect));
+    py::class_<NNData, Buffer, std::shared_ptr<NNData>> nnData(m, "NNData", DOC(dai, NNData));
+    py::class_<ImgDetections, Buffer, std::shared_ptr<ImgDetections>> imgDetections(m, "ImgDetections", DOC(dai, ImgDetections));
+    py::class_<SpatialImgDetections, Buffer, std::shared_ptr<SpatialImgDetections>> spatialImgDetections(m, "SpatialImgDetections", DOC(dai, SpatialImgDetections));
+    py::class_<ImageManipConfig, Buffer, std::shared_ptr<ImageManipConfig>> imageManipConfig(m, "ImageManipConfig", DOC(dai, ImageManipConfig));
+    py::class_<CameraControl, Buffer, std::shared_ptr<CameraControl>> cameraControl(m, "CameraControl", DOC(dai, CameraControl));
+    py::class_<SystemInformation, Buffer, std::shared_ptr<SystemInformation>> systemInformation(m, "SystemInformation", DOC(dai, SystemInformation));
+    py::class_<SpatialLocations> spatialLocations(m, "SpatialLocations", DOC(dai, SpatialLocations));
+    py::class_<Rect> rect(m, "Rect", DOC(dai, Rect));
+    py::class_<SpatialLocationCalculatorConfigThresholds> spatialLocationCalculatorConfigThresholds(m, "SpatialLocationCalculatorConfigThresholds", DOC(dai, SpatialLocationCalculatorConfigThresholds));
+    py::class_<SpatialLocationCalculatorConfigData> spatialLocationCalculatorConfigData(m, "SpatialLocationCalculatorConfigData", DOC(dai, SpatialLocationCalculatorConfigData));
+    py::class_<SpatialLocationCalculatorData, Buffer, std::shared_ptr<SpatialLocationCalculatorData>> spatialLocationCalculatorData(m, "SpatialLocationCalculatorData", DOC(dai, SpatialLocationCalculatorData));
+    py::class_<SpatialLocationCalculatorConfig, Buffer, std::shared_ptr<SpatialLocationCalculatorConfig>> spatialLocationCalculatorConfig(m, "SpatialLocationCalculatorConfig", DOC(dai, SpatialLocationCalculatorConfig));
+    py::class_<Tracklets, Buffer, std::shared_ptr<Tracklets>> tracklets(m, "Tracklets", DOC(dai, Tracklets));
+    py::class_<IMUData, Buffer, std::shared_ptr<IMUData>> imuData(m, "IMUData", DOC(dai, IMUData));
+    py::class_<RawStereoDepthConfig, RawBuffer, std::shared_ptr<RawStereoDepthConfig>> rawStereoDepthConfig(m, "RawStereoDepthConfig", DOC(dai, RawStereoDepthConfig));
+    py::class_<StereoDepthConfig, Buffer, std::shared_ptr<StereoDepthConfig>> stereoDepthConfig(m, "StereoDepthConfig", DOC(dai, StereoDepthConfig));
+    py::class_<EdgeDetectorConfigData> edgeDetectorConfigData(m, "EdgeDetectorConfigData", DOC(dai, EdgeDetectorConfigData));
+    py::class_<RawEdgeDetectorConfig, RawBuffer, std::shared_ptr<RawEdgeDetectorConfig>> rawEdgeDetectorConfig(m, "RawEdgeDetectorConfig", DOC(dai, RawEdgeDetectorConfig));
+    py::class_<EdgeDetectorConfig, Buffer, std::shared_ptr<EdgeDetectorConfig>> edgeDetectorConfig(m, "EdgeDetectorConfig", DOC(dai, EdgeDetectorConfig));
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+
+    rawBuffer
         .def(py::init<>())
         .def_property("data", [](py::object &obj){
             dai::RawBuffer &a = obj.cast<dai::RawBuffer&>();
@@ -62,8 +135,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
 
-    // Bind RawImgFrame
-    py::class_<RawImgFrame, RawBuffer, std::shared_ptr<RawImgFrame>> rawImgFrame(m, "RawImgFrame", DOC(dai, RawImgFrame));
+
     rawImgFrame
         .def(py::init<>())
         .def_readwrite("fb", &RawImgFrame::fb)
@@ -92,7 +164,8 @@ void DatatypeBindings::bind(pybind11::module& m){
         )
         ;
 
-    py::enum_<RawImgFrame::Type>(rawImgFrame, "Type")
+
+    rawImgFrameType
         .value("YUV422i", RawImgFrame::Type::YUV422i)
         .value("YUV444p", RawImgFrame::Type::YUV444p)
         .value("YUV420p", RawImgFrame::Type::YUV420p)
@@ -128,7 +201,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .value("NONE", RawImgFrame::Type::NONE)
         ;
 
-    py::class_<RawImgFrame::Specs>(rawImgFrame, "Specs", DOC(dai, RawImgFrame, Specs))
+    rawImgFrameSpecs
         .def(py::init<>())
         .def_readwrite("type", &RawImgFrame::Specs::type)
         .def_readwrite("width", &RawImgFrame::Specs::width)
@@ -141,15 +214,12 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
 
-    // NNData
-    py::class_<RawNNData, RawBuffer, std::shared_ptr<RawNNData>> rawNnData(m, "RawNNData", DOC(dai, RawNNData));
     rawNnData
         .def(py::init<>())
         .def_readwrite("tensors", &RawNNData::tensors)
         .def_readwrite("batchSize", &RawNNData::batchSize)
         ;
 
-    py::class_<TensorInfo> tensorInfo(m, "TensorInfo", DOC(dai, TensorInfo));
     tensorInfo
         .def(py::init<>())
         .def_readwrite("order", &TensorInfo::order)
@@ -161,7 +231,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("offset", &TensorInfo::offset)
         ;
 
-    py::enum_<TensorInfo::DataType>(tensorInfo, "DataType")
+    tensorInfoDataType
         .value("FP16", TensorInfo::DataType::FP16)
         .value("U8F", TensorInfo::DataType::U8F)
         .value("INT", TensorInfo::DataType::INT)
@@ -169,7 +239,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .value("I8", TensorInfo::DataType::I8)
         ;
 
-    py::enum_<TensorInfo::StorageOrder>(tensorInfo, "StorageOrder")
+    tensorInfoStorageOrder
         .value("NHWC", TensorInfo::StorageOrder::NHWC)
         .value("NHCW", TensorInfo::StorageOrder::NHCW)
         .value("NCHW", TensorInfo::StorageOrder::NCHW)
@@ -186,7 +256,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .value("W", TensorInfo::StorageOrder::W)
         ;
 
-    py::class_<ImgDetection>(m, "ImgDetection", DOC(dai, ImgDetection))
+    imgDetection
         .def(py::init<>())
         .def_readwrite("label", &ImgDetection::label)
         .def_readwrite("confidence", &ImgDetection::confidence)
@@ -196,25 +266,23 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("ymax", &ImgDetection::ymax)
         ;
 
-    py::class_<SpatialImgDetection, ImgDetection>(m, "SpatialImgDetection", DOC(dai, SpatialImgDetection))
+
+    spatialImgDetection
         .def(py::init<>())
         .def_readwrite("spatialCoordinates", &SpatialImgDetection::spatialCoordinates)
         ;
 
-    py::class_<RawImgDetections, RawBuffer, std::shared_ptr<RawImgDetections>> RawImgDetections(m, "RawImgDetections", DOC(dai, RawImgDetections));
-    RawImgDetections
+    rawImgDetections
         .def(py::init<>())
         .def_readwrite("detections", &RawImgDetections::detections)
         ;
 
-    py::class_<RawSpatialImgDetections, RawBuffer, std::shared_ptr<RawSpatialImgDetections>> RawSpatialImgDetections(m, "RawSpatialImgDetections", DOC(dai, RawSpatialImgDetections));
-    RawSpatialImgDetections
+    rawSpatialImgDetections
         .def(py::init<>())
         .def_readwrite("detections", &RawSpatialImgDetections::detections)
         ;
 
     // Bind RawImageManipConfig
-    py::class_<RawImageManipConfig, RawBuffer, std::shared_ptr<RawImageManipConfig>> rawImageManipConfig(m, "RawImageManipConfig", DOC(dai, RawImageManipConfig));
     rawImageManipConfig
         .def(py::init<>())
         .def_readwrite("enableFormat", &RawImageManipConfig::enableFormat)
@@ -225,7 +293,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("formatConfig", &RawImageManipConfig::formatConfig)
         ;
 
-    py::class_<RawImageManipConfig::CropRect>(rawImageManipConfig, "CropRect", DOC(dai, RawImageManipConfig, CropRect))
+    rawImageManipConfigCropRect
         .def(py::init<>())
         .def_readwrite("xmin", &RawImageManipConfig::CropRect::xmin)
         .def_readwrite("ymin", &RawImageManipConfig::CropRect::ymin)
@@ -233,7 +301,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("ymax", &RawImageManipConfig::CropRect::ymax)
         ;
 
-    py::class_<RawImageManipConfig::CropConfig>(rawImageManipConfig, "CropConfig", DOC(dai, RawImageManipConfig, CropConfig))
+    rawImageManipCropConfig
         .def(py::init<>())
         .def_readwrite("cropRect", &RawImageManipConfig::CropConfig::cropRect)
         .def_readwrite("cropRotatedRect", &RawImageManipConfig::CropConfig::cropRotatedRect)
@@ -244,7 +312,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("normalizedCoords", &RawImageManipConfig::CropConfig::normalizedCoords)
         ;
 
-    py::class_<RawImageManipConfig::ResizeConfig>(rawImageManipConfig, "ResizeConfig", DOC(dai, RawImageManipConfig, ResizeConfig))
+    rawImageManipConfigResizeConfig
         .def(py::init<>())
         .def_readwrite("width", &RawImageManipConfig::ResizeConfig::width)
         .def_readwrite("height", &RawImageManipConfig::ResizeConfig::height)
@@ -263,7 +331,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("keepAspectRatio", &RawImageManipConfig::ResizeConfig::keepAspectRatio)
         ;
 
-    py::class_<RawImageManipConfig::FormatConfig>(rawImageManipConfig, "FormatConfig", DOC(dai, RawImageManipConfig, FormatConfig))
+    rawImageManipConfigFormatConfig
         .def(py::init<>())
         .def_readwrite("type", &RawImageManipConfig::FormatConfig::type)
         .def_readwrite("flipHorizontal", &RawImageManipConfig::FormatConfig::flipHorizontal)
@@ -271,7 +339,6 @@ void DatatypeBindings::bind(pybind11::module& m){
 
 
     // Bind RawCameraControl
-    py::class_<RawCameraControl, RawBuffer, std::shared_ptr<RawCameraControl>> rawCameraControl(m, "RawCameraControl", DOC(dai, RawCameraControl));
     rawCameraControl
         .def(py::init<>())
         .def_readwrite("cmdMask", &RawCameraControl::cmdMask)
@@ -280,7 +347,6 @@ void DatatypeBindings::bind(pybind11::module& m){
         // TODO add more raw types here, not directly used
         ;
 
-    py::class_<Tracklet> tracklet(m, "Tracklet", DOC(dai, Tracklet));
     tracklet
         .def(py::init<>())
         .def_readwrite("roi", &Tracklet::roi)
@@ -291,7 +357,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("spatialCoordinates", &Tracklet::spatialCoordinates)
         ;
 
-    py::enum_<Tracklet::TrackingStatus>(tracklet, "TrackingStatus", DOC(dai, Tracklet, TrackingStatus))
+    trackletTrackingStatus
         .value("NEW", Tracklet::TrackingStatus::NEW)
         .value("TRACKED", Tracklet::TrackingStatus::TRACKED)
         .value("LOST", Tracklet::TrackingStatus::LOST)
@@ -299,50 +365,49 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
     // Bind RawTracklets
-    py::class_<RawTracklets, RawBuffer, std::shared_ptr<RawTracklets>> rawTacklets(m, "RawTracklets", DOC(dai, RawTracklets));
     rawTacklets
         .def(py::init<>())
         .def_readwrite("tracklets", &RawTracklets::tracklets)
         ;
 
 
-    py::class_<IMUReport, std::shared_ptr<IMUReport>> imureport(m, "IMUReport", DOC(dai, IMUReport));
-    imureport
+    imuReport
         .def(py::init<>())
         .def_readwrite("sequence", &IMUReport::sequence)
         .def_readwrite("accuracy", &IMUReport::accuracy)
         .def_readwrite("timestamp", &IMUReport::timestamp)
         ;
 
-    py::enum_<IMUReport::Accuracy>(imureport, "Accuracy")
+
+    imuReportAccuracy
         .value("UNRELIABLE", IMUReport::Accuracy::UNRELIABLE)
         .value("LOW", IMUReport::Accuracy::LOW)
         .value("MEDIUM", IMUReport::Accuracy::MEDIUM)
         .value("HIGH", IMUReport::Accuracy::HIGH)
         ;
 
-    py::class_<IMUReportAccelerometer, IMUReport, std::shared_ptr<IMUReportAccelerometer>>(m, "IMUReportAccelerometer", DOC(dai, IMUReportAccelerometer))
+    imuReportAccelerometer
         .def(py::init<>())
         .def_readwrite("x", &IMUReportAccelerometer::x)
         .def_readwrite("y", &IMUReportAccelerometer::y)
         .def_readwrite("z", &IMUReportAccelerometer::z)
         ;
 
-    py::class_<IMUReportGyroscope, IMUReport, std::shared_ptr<IMUReportGyroscope>>(m, "IMUReportGyroscope", DOC(dai, IMUReportGyroscope))
+    imuReportGyroscope
         .def(py::init<>())
         .def_readwrite("x", &IMUReportGyroscope::x)
         .def_readwrite("y", &IMUReportGyroscope::y)
         .def_readwrite("z", &IMUReportGyroscope::z)
         ;
 
-    py::class_<IMUReportMagneticField, IMUReport, std::shared_ptr<IMUReportMagneticField>>(m, "IMUReportMagneticField", DOC(dai, IMUReportMagneticField))
+    imuReportMagneticField
         .def(py::init<>())
         .def_readwrite("x", &IMUReportMagneticField::x)
         .def_readwrite("y", &IMUReportMagneticField::y)
         .def_readwrite("z", &IMUReportMagneticField::z)
         ;
 
-    py::class_<IMUReportRotationVectorWAcc, IMUReport, std::shared_ptr<IMUReportRotationVectorWAcc>>(m, "IMUReportRotationVectorWAcc", DOC(dai, IMUReportRotationVectorWAcc))
+    imuReportRotationVectorWAcc
         .def(py::init<>())
         .def_readwrite("i", &IMUReportRotationVectorWAcc::i)
         .def_readwrite("j", &IMUReportRotationVectorWAcc::j)
@@ -393,8 +458,7 @@ void DatatypeBindings::bind(pybind11::module& m){
 
 #endif
 
-    py::class_<IMUPacket> imuPackets(m, "IMUPacket", DOC(dai, IMUPacket));
-    imuPackets
+    imuPacket
         .def(py::init<>())
         .def_readwrite("acceleroMeter", &IMUPacket::acceleroMeter)
         .def_readwrite("gyroscope", &IMUPacket::gyroscope)
@@ -418,7 +482,6 @@ void DatatypeBindings::bind(pybind11::module& m){
 
 
     // Bind RawIMUData
-    py::class_<RawIMUData, RawBuffer, std::shared_ptr<RawIMUData>> rawIMUPackets(m, "RawIMUData", DOC(dai, RawIMUData));
     rawIMUPackets
         .def(py::init<>())
         .def_readwrite("packets", &RawIMUData::packets)
@@ -428,7 +491,7 @@ void DatatypeBindings::bind(pybind11::module& m){
     // The enum fields will also be exposed in 'CameraControl', store them for later
     std::vector<const char *> camCtrlAttr;
     camCtrlAttr.push_back("AutoFocusMode");
-    py::enum_<RawCameraControl::AutoFocusMode>(rawCameraControl, "AutoFocusMode", DOC(dai, RawCameraControl, AutoFocusMode))
+    rawCameraControlAutoFocusMode
         .value("OFF", RawCameraControl::AutoFocusMode::OFF)
         .value("AUTO", RawCameraControl::AutoFocusMode::AUTO)
         .value("MACRO", RawCameraControl::AutoFocusMode::MACRO)
@@ -438,7 +501,7 @@ void DatatypeBindings::bind(pybind11::module& m){
     ;
 
     camCtrlAttr.push_back("AutoWhiteBalanceMode");
-    py::enum_<RawCameraControl::AutoWhiteBalanceMode>(rawCameraControl, "AutoWhiteBalanceMode", DOC(dai, RawCameraControl, AutoWhiteBalanceMode))
+    rawCameraControlAutoWhiteBalanceMode
         .value("OFF", RawCameraControl::AutoWhiteBalanceMode::OFF)
         .value("AUTO", RawCameraControl::AutoWhiteBalanceMode::AUTO)
         .value("INCANDESCENT", RawCameraControl::AutoWhiteBalanceMode::INCANDESCENT)
@@ -451,7 +514,7 @@ void DatatypeBindings::bind(pybind11::module& m){
     ;
 
     camCtrlAttr.push_back("SceneMode");
-    py::enum_<RawCameraControl::SceneMode>(rawCameraControl, "SceneMode", DOC(dai, RawCameraControl, SceneMode))
+    rawCameraControlSceneMode
         .value("UNSUPPORTED", RawCameraControl::SceneMode::UNSUPPORTED)
         .value("FACE_PRIORITY", RawCameraControl::SceneMode::FACE_PRIORITY)
         .value("ACTION", RawCameraControl::SceneMode::ACTION)
@@ -472,7 +535,7 @@ void DatatypeBindings::bind(pybind11::module& m){
     ;
 
     camCtrlAttr.push_back("AntiBandingMode");
-    py::enum_<RawCameraControl::AntiBandingMode>(rawCameraControl, "AntiBandingMode", DOC(dai, RawCameraControl, AntiBandingMode))
+    rawCameraControlAntiBandingMode
         .value("OFF", RawCameraControl::AntiBandingMode::OFF)
         .value("MAINS_50_HZ", RawCameraControl::AntiBandingMode::MAINS_50_HZ)
         .value("MAINS_60_HZ", RawCameraControl::AntiBandingMode::MAINS_60_HZ)
@@ -480,7 +543,7 @@ void DatatypeBindings::bind(pybind11::module& m){
     ;
 
     camCtrlAttr.push_back("EffectMode");
-    py::enum_<RawCameraControl::EffectMode>(rawCameraControl, "EffectMode", DOC(dai, RawCameraControl, EffectMode))
+    rawCameraControlEffectMode
         .value("OFF", RawCameraControl::EffectMode::OFF)
         .value("MONO", RawCameraControl::EffectMode::MONO)
         .value("NEGATIVE", RawCameraControl::EffectMode::NEGATIVE)
@@ -493,7 +556,6 @@ void DatatypeBindings::bind(pybind11::module& m){
     ;
 
     // Bind RawSystemInformation
-    py::class_<RawSystemInformation, RawBuffer, std::shared_ptr<RawSystemInformation>> rawSystemInformation(m, "RawSystemInformation", DOC(dai, RawSystemInformation));
     rawSystemInformation
         .def(py::init<>())
         .def_readwrite("ddrMemoryUsage", &RawSystemInformation::ddrMemoryUsage)
@@ -507,10 +569,11 @@ void DatatypeBindings::bind(pybind11::module& m){
 
 
     // Bind non-raw 'helper' datatypes
-    py::class_<ADatatype, std::shared_ptr<ADatatype>>(m, "ADatatype", DOC(dai, ADatatype))
+    adatatype
         .def("getRaw", &ADatatype::getRaw);
 
-    py::class_<Buffer, ADatatype, std::shared_ptr<Buffer>>(m, "Buffer", DOC(dai, Buffer))
+
+    buffer
         .def(py::init<>(), DOC(dai, Buffer, Buffer))
 
         // obj is "Python" object, which we used then to bind the numpy arrays lifespan to
@@ -527,7 +590,7 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
     // Bind ImgFrame
-    py::class_<ImgFrame, Buffer, std::shared_ptr<ImgFrame>>(m, "ImgFrame", DOC(dai, ImgFrame))
+    imgFrame
         .def(py::init<>())
         // getters
         .def("getTimestamp", &ImgFrame::getTimestamp, DOC(dai, ImgFrame, getTimestamp))
@@ -735,7 +798,7 @@ void DatatypeBindings::bind(pybind11::module& m){
     m.attr("ImgFrame").attr("Type") = m.attr("RawImgFrame").attr("Type");
     m.attr("ImgFrame").attr("Specs") = m.attr("RawImgFrame").attr("Specs");
 
-    py::class_<RotatedRect>(m, "RotatedRect", DOC(dai, RotatedRect))
+    rotatedRect
         .def(py::init<>())
         .def_readwrite("center", &RotatedRect::center)
         .def_readwrite("size", &RotatedRect::size)
@@ -743,7 +806,8 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
     // Bind NNData
-    py::class_<NNData, Buffer, std::shared_ptr<NNData>>(m, "NNData", DOC(dai, NNData))
+
+    nnData
         .def(py::init<>(), DOC(dai, NNData, NNData))
         // setters
         .def("setLayer", [](NNData& obj, const std::string& name, py::array_t<std::uint8_t, py::array::c_style | py::array::forcecast> data){
@@ -767,19 +831,22 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
     // Bind ImgDetections
-    py::class_<ImgDetections, Buffer, std::shared_ptr<ImgDetections>>(m, "ImgDetections", DOC(dai, ImgDetections))
+
+    imgDetections
         .def(py::init<>(), DOC(dai, ImgDetections, ImgDetections))
         .def_property("detections", [](ImgDetections& det) { return &det.detections; }, [](ImgDetections& det, std::vector<ImgDetection> val) { det.detections = val; }, DOC(dai, ImgDetections, detections))
         ;
 
     // Bind SpatialImgDetections
-    py::class_<SpatialImgDetections, Buffer, std::shared_ptr<SpatialImgDetections>>(m, "SpatialImgDetections", DOC(dai, SpatialImgDetections))
+
+    spatialImgDetections
         .def(py::init<>())
         .def_property("detections", [](SpatialImgDetections& det) { return &det.detections; }, [](SpatialImgDetections& det, std::vector<SpatialImgDetection> val) { det.detections = val; })
         ;
 
      // Bind ImageManipConfig
-    py::class_<ImageManipConfig, Buffer, std::shared_ptr<ImageManipConfig>>(m, "ImageManipConfig", DOC(dai, ImageManipConfig))
+
+    imageManipConfig
         .def(py::init<>())
         // setters
         .def("setCropRect", &ImageManipConfig::setCropRect, py::arg("xmin"), py::arg("ymin"), py::arg("xmax"), py::arg("xmax"), DOC(dai, ImageManipConfig, setCropRect))
@@ -810,7 +877,8 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
     // Bind CameraControl
-    py::class_<CameraControl, Buffer, std::shared_ptr<CameraControl>>(m, "CameraControl", DOC(dai, CameraControl))
+
+    cameraControl
         .def(py::init<>(), DOC(dai, CameraControl, CameraControl))
         // setters
         .def("setCaptureStill", &CameraControl::setCaptureStill, py::arg("capture"), DOC(dai, CameraControl, setCaptureStill))
@@ -845,7 +913,8 @@ void DatatypeBindings::bind(pybind11::module& m){
     }
 
     // Bind SystemInformation
-    py::class_<SystemInformation, Buffer, std::shared_ptr<SystemInformation>>(m, "SystemInformation", DOC(dai, SystemInformation))
+
+    systemInformation
         .def(py::init<>())
         .def_property("ddrMemoryUsage", [](SystemInformation& i) { return &i.ddrMemoryUsage; }, [](SystemInformation& i, MemoryInfo val) { i.ddrMemoryUsage = val; } )
         .def_property("cmxMemoryUsage", [](SystemInformation& i) { return &i.cmxMemoryUsage; }, [](SystemInformation& i, MemoryInfo val) { i.cmxMemoryUsage = val; } )
@@ -856,7 +925,8 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_property("chipTemperature", [](SystemInformation& i) { return &i.chipTemperature; }, [](SystemInformation& i, ChipTemperature val) { i.chipTemperature = val; } )
         ;
 
-    py::class_<SpatialLocations> (m, "SpatialLocations", DOC(dai, SpatialLocations))
+
+    spatialLocations
         .def(py::init<>())
         .def_readwrite("config", &SpatialLocations::config, DOC(dai, SpatialLocations, config))
         .def_readwrite("depthAverage", &SpatialLocations::depthAverage, DOC(dai, SpatialLocations, depthAverage))
@@ -867,7 +937,8 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
 
-    py::class_<Rect> (m, "Rect", DOC(dai, Rect))
+
+    rect
         .def(py::init<>())
         .def(py::init<float, float, float, float>())
         .def(py::init<Point2f, Point2f>())
@@ -888,26 +959,30 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def_readwrite("height", &Rect::height)
         ;
 
-    py::class_<SpatialLocationCalculatorConfigThresholds> (m, "SpatialLocationCalculatorConfigThresholds", DOC(dai, SpatialLocationCalculatorConfigThresholds))
+
+    spatialLocationCalculatorConfigThresholds
         .def(py::init<>())
         .def_readwrite("lowerThreshold", &SpatialLocationCalculatorConfigThresholds::lowerThreshold)
         .def_readwrite("upperThreshold", &SpatialLocationCalculatorConfigThresholds::upperThreshold)
         ;
 
-    py::class_<SpatialLocationCalculatorConfigData> (m, "SpatialLocationCalculatorConfigData", DOC(dai, SpatialLocationCalculatorConfigData))
+
+    spatialLocationCalculatorConfigData
         .def(py::init<>())
         .def_readwrite("roi", &SpatialLocationCalculatorConfigData::roi)
         .def_readwrite("depthThresholds", &SpatialLocationCalculatorConfigData::depthThresholds)
         ;
 
     // Bind SpatialLocationCalculatorData
-    py::class_<SpatialLocationCalculatorData, Buffer, std::shared_ptr<SpatialLocationCalculatorData>>(m, "SpatialLocationCalculatorData", DOC(dai, SpatialLocationCalculatorData))
+
+    spatialLocationCalculatorData
         .def(py::init<>())
         .def("getSpatialLocations", &SpatialLocationCalculatorData::getSpatialLocations, DOC(dai, SpatialLocationCalculatorData, getSpatialLocations))
         ;
 
     // SpatialLocationCalculatorConfig (after ConfigData)
-    py::class_<SpatialLocationCalculatorConfig, Buffer, std::shared_ptr<SpatialLocationCalculatorConfig>>(m, "SpatialLocationCalculatorConfig", DOC(dai, SpatialLocationCalculatorConfig))
+
+    spatialLocationCalculatorConfig
         .def(py::init<>())
         // setters
         .def("setROIs", &SpatialLocationCalculatorConfig::setROIs, py::arg("ROIs"), DOC(dai, SpatialLocationCalculatorConfig, setROIs))
@@ -916,27 +991,27 @@ void DatatypeBindings::bind(pybind11::module& m){
         ;
 
     // Tracklets (after ConfigData)
-    py::class_<Tracklets, Buffer, std::shared_ptr<Tracklets>>(m, "Tracklets", DOC(dai, Tracklets))
+
+    tracklets
         .def(py::init<>())
         .def_property("tracklets", [](Tracklets& track) { return &track.tracklets; }, [](Tracklets& track, std::vector<Tracklet> val) { track.tracklets = val; }, DOC(dai, Tracklets, tracklets))
         ;
 
 
-    // IMUData (after ConfigData)
-    py::class_<IMUData, Buffer, std::shared_ptr<IMUData>>(m, "IMUData", DOC(dai, IMUData))
+
+    imuData
         .def(py::init<>())
         .def_property("packets", [](IMUData& imuDta) { return &imuDta.packets; }, [](IMUData& imuDta, std::vector<IMUPacket> val) { imuDta.packets = val; }, DOC(dai, IMUData, packets))
         ;
 
-    // Bind RawStereoDepthConfig
-    py::class_<RawStereoDepthConfig, RawBuffer, std::shared_ptr<RawStereoDepthConfig>> rawStereoDepthConfig(m, "RawStereoDepthConfig", DOC(dai, RawStereoDepthConfig));
+
     rawStereoDepthConfig
         .def(py::init<>())
         .def_readwrite("config", &RawStereoDepthConfig::config)
         ;
 
-    // StereoDepthConfig (after ConfigData)
-    py::class_<StereoDepthConfig, Buffer, std::shared_ptr<StereoDepthConfig>>(m, "StereoDepthConfig", DOC(dai, StereoDepthConfig))
+
+    stereoDepthConfig
         .def(py::init<>())
         .def("setConfidenceThreshold",  &StereoDepthConfig::setConfidenceThreshold, py::arg("confThr"), DOC(dai, StereoDepthConfig, setConfidenceThreshold))
         .def("setMedianFilter",         &StereoDepthConfig::setMedianFilter, py::arg("median"), DOC(dai, StereoDepthConfig, setMedianFilter))
@@ -948,22 +1023,20 @@ void DatatypeBindings::bind(pybind11::module& m){
         .def("getLeftRightCheckThreshold",         &StereoDepthConfig::getLeftRightCheckThreshold, DOC(dai, StereoDepthConfig, getLeftRightCheckThreshold))
         ;
 
-
-    py::class_<EdgeDetectorConfigData> (m, "EdgeDetectorConfigData", DOC(dai, EdgeDetectorConfigData))
+    edgeDetectorConfigData
         .def(py::init<>())
         .def_readwrite("sobelFilterHorizontalKernel", &EdgeDetectorConfigData::sobelFilterHorizontalKernel, DOC(dai, EdgeDetectorConfigData, sobelFilterHorizontalKernel))
         .def_readwrite("sobelFilterVerticalKernel", &EdgeDetectorConfigData::sobelFilterVerticalKernel, DOC(dai, EdgeDetectorConfigData, sobelFilterVerticalKernel))
         ;
 
-    // Bind RawEdgeDetectorConfig
-    py::class_<RawEdgeDetectorConfig, RawBuffer, std::shared_ptr<RawEdgeDetectorConfig>> rawEdgeDetectorConfig(m, "RawEdgeDetectorConfig", DOC(dai, RawEdgeDetectorConfig));
+
     rawEdgeDetectorConfig
         .def(py::init<>())
         .def_readwrite("config", &RawEdgeDetectorConfig::config)
         ;
 
-    // EdgeDetectorConfig (after ConfigData)
-    py::class_<EdgeDetectorConfig, Buffer, std::shared_ptr<EdgeDetectorConfig>>(m, "EdgeDetectorConfig", DOC(dai, EdgeDetectorConfig))
+
+    edgeDetectorConfig
         .def(py::init<>())
         .def("setSobelFilterKernels",  &EdgeDetectorConfig::setSobelFilterKernels, py::arg("horizontalKernel"), py::arg("verticalKernel"), DOC(dai, EdgeDetectorConfig, setSobelFilterKernels))
         .def("getConfigData",         &EdgeDetectorConfig::getConfigData, DOC(dai, EdgeDetectorConfig, getConfigData))

--- a/src/DatatypeBindings.hpp
+++ b/src/DatatypeBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct DatatypeBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -112,13 +112,30 @@ std::vector<std::string> deviceGetQueueEventsHelper(dai::Device& d, const std::v
 }
 
 
-void DeviceBindings::bind(pybind11::module& m){
+void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
+    // Type definitions
+    py::class_<Device> device(m, "Device", DOC(dai, Device));
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+
 
     // Bind Device, using DeviceWrapper to be able to destruct the object by calling close()
-    py::class_<Device>(m, "Device", DOC(dai, Device))
+    device
         // Python only methods
         .def("__enter__", [](py::object obj){ return obj; })
         .def("__exit__", [](Device& d, py::object type, py::object value, py::object traceback) {

--- a/src/DeviceBindings.hpp
+++ b/src/DeviceBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct DeviceBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/DeviceBootloaderBindings.cpp
+++ b/src/DeviceBootloaderBindings.cpp
@@ -3,14 +3,33 @@
 // depthai
 #include "depthai/device/DeviceBootloader.hpp"
 
-void DeviceBootloaderBindings::bind(pybind11::module& m){
+void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
-    // Bind DeviceBootloader
+    // Type definitions
     py::class_<DeviceBootloader> deviceBootloader(m, "DeviceBootloader", DOC(dai, DeviceBootloader));
+    py::class_<DeviceBootloader::Version> deviceBootloaderVersion(deviceBootloader, "Version", DOC(dai, DeviceBootloader, Version));
+    py::enum_<DeviceBootloader::Type> deviceBootloaderType(deviceBootloader, "Type");
+    py::enum_<DeviceBootloader::Memory> deviceBootloaderMemory(deviceBootloader, "Memory");
+    py::enum_<DeviceBootloader::Section> deviceBootloaderSection(deviceBootloader, "Section");
 
-    py::class_<DeviceBootloader::Version>(deviceBootloader, "Version", DOC(dai, DeviceBootloader, Version))
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+
+    // Bind DeviceBootloader
+    deviceBootloaderVersion
         .def(py::init<const std::string&>(), py::arg("v"), DOC(dai, DeviceBootloader, Version, Version))
         .def(py::init<unsigned, unsigned, unsigned>(), py::arg("major"), py::arg("minor"), py::arg("patch"), DOC(dai, DeviceBootloader, Version, Version, 2))
         .def("__str__", &DeviceBootloader::Version::toString)
@@ -19,15 +38,15 @@ void DeviceBootloaderBindings::bind(pybind11::module& m){
         .def("__gt__", &DeviceBootloader::Version::operator>)
         ;
 
-    py::enum_<DeviceBootloader::Type>(deviceBootloader, "Type")
+    deviceBootloaderType
         .value("USB", DeviceBootloader::Type::USB)
         .value("NETWORK", DeviceBootloader::Type::NETWORK)
         ;
-    py::enum_<DeviceBootloader::Memory>(deviceBootloader, "Memory")
+    deviceBootloaderMemory
         .value("FLASH", DeviceBootloader::Memory::FLASH)
         .value("EMMC", DeviceBootloader::Memory::EMMC)
         ;
-    py::enum_<DeviceBootloader::Section>(deviceBootloader, "Section")
+    deviceBootloaderSection
         .value("HEADER", DeviceBootloader::Section::HEADER)
         .value("BOOTLOADER", DeviceBootloader::Section::BOOTLOADER)
         .value("BOOTLOADER_CONFIG", DeviceBootloader::Section::BOOTLOADER_CONFIG)

--- a/src/DeviceBootloaderBindings.hpp
+++ b/src/DeviceBootloaderBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct DeviceBootloaderBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/XLinkConnectionBindings.cpp
+++ b/src/XLinkConnectionBindings.cpp
@@ -5,18 +5,41 @@
 #include <cmath>
 #include <cstring>
 
-void XLinkConnectionBindings::bind(pybind11::module& m){
+void XLinkConnectionBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
-    py::class_<DeviceInfo>(m, "DeviceInfo", DOC(dai, DeviceInfo))
+
+    // Type definitions
+    py::class_<DeviceInfo> deviceInfo(m, "DeviceInfo", DOC(dai, DeviceInfo));
+    py::class_<deviceDesc_t> deviceDesc(m, "DeviceDesc");
+    py::enum_<XLinkDeviceState_t> xLinkDeviceState(m, "XLinkDeviceState");
+    py::enum_<XLinkProtocol_t> xLinkProtocol(m, "XLinkProtocol");
+    py::enum_<XLinkPlatform_t> xLinkPlatform(m, "XLinkPlatform");
+    py::class_<XLinkConnection, std::shared_ptr<XLinkConnection>> xLinkConnection(m, "XLinkConnection", DOC(dai, XLinkConnection));
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+    // Bindings
+    deviceInfo
         .def(py::init<>())
         .def_readwrite("desc", &DeviceInfo::desc)
         .def_readwrite("state", &DeviceInfo::state)
         .def("getMxId", &DeviceInfo::getMxId)
         ;
 
-    py::class_<deviceDesc_t>(m, "DeviceDesc")
+    deviceDesc
         .def(py::init<>())
         .def_readwrite("protocol", &deviceDesc_t::protocol)
         .def_readwrite("platform", &deviceDesc_t::platform)
@@ -26,7 +49,7 @@ void XLinkConnectionBindings::bind(pybind11::module& m){
         )
         ;
 
-    py::enum_<XLinkDeviceState_t>(m, "XLinkDeviceState")
+    xLinkDeviceState
         .value("X_LINK_ANY_STATE", X_LINK_ANY_STATE)
         .value("X_LINK_BOOTED", X_LINK_BOOTED)
         .value("X_LINK_UNBOOTED", X_LINK_UNBOOTED)
@@ -35,7 +58,7 @@ void XLinkConnectionBindings::bind(pybind11::module& m){
         ;
 
 
-    py::enum_<XLinkProtocol_t>(m, "XLinkProtocol")
+    xLinkProtocol
         .value("X_LINK_USB_VSC", X_LINK_USB_VSC)
         .value("X_LINK_USB_CDC", X_LINK_USB_CDC)
         .value("X_LINK_PCIE", X_LINK_PCIE)
@@ -46,14 +69,14 @@ void XLinkConnectionBindings::bind(pybind11::module& m){
         .export_values()
         ;
 
-    py::enum_<XLinkPlatform_t>(m, "XLinkPlatform")
+    xLinkPlatform
         .value("X_LINK_ANY_PLATFORM", X_LINK_ANY_PLATFORM)
         .value("X_LINK_MYRIAD_2", X_LINK_MYRIAD_2)
         .value("X_LINK_MYRIAD_X", X_LINK_MYRIAD_X)
         .export_values()
         ;
 
-    py::class_<XLinkConnection>(m, "XLinkConnection", DOC(dai, XLinkConnection))
+    xLinkConnection
         .def(py::init<const DeviceInfo&, std::vector<std::uint8_t>>())
         .def(py::init<const DeviceInfo&, std::string>())
         .def(py::init<const DeviceInfo&>())

--- a/src/XLinkConnectionBindings.hpp
+++ b/src/XLinkConnectionBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct XLinkConnectionBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/log/LogBindings.cpp
+++ b/src/log/LogBindings.cpp
@@ -3,12 +3,29 @@
 // depthai
 #include "depthai-shared/log/LogLevel.hpp"
 
-void LogBindings::bind(pybind11::module& m){
+void LogBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
     // Bind LogLevel
-    py::enum_<LogLevel>(m, "LogLevel")
+    py::enum_<LogLevel> logLevel(m, "LogLevel");
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+
+    logLevel
         .value("TRACE", LogLevel::TRACE)
         .value("DEBUG", LogLevel::DEBUG)
         .value("INFO", LogLevel::INFO)
@@ -17,5 +34,5 @@ void LogBindings::bind(pybind11::module& m){
         .value("CRITICAL", LogLevel::CRITICAL)
         .value("OFF", LogLevel::OFF)
     ;
-     
+
 }

--- a/src/log/LogBindings.hpp
+++ b/src/log/LogBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct LogBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/openvino/OpenVINOBindings.cpp
+++ b/src/openvino/OpenVINOBindings.cpp
@@ -3,12 +3,31 @@
 // depthai
 #include "depthai/openvino/OpenVINO.hpp"
 
-void OpenVINOBindings::bind(pybind11::module& m){
+void OpenVINOBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
-    // Bind OpenVINO
     py::class_<OpenVINO> openvino(m, "OpenVINO", DOC(dai, OpenVINO));
+    py::enum_<OpenVINO::Version> openvinoVersion(openvino, "Version", DOC(dai, OpenVINO, Version));
+
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+
+
+    // Bind OpenVINO
     openvino
         .def_static("getVersions", &OpenVINO::getVersions, DOC(dai, OpenVINO, getVersions))
         .def_static("getVersionName", &OpenVINO::getVersionName, py::arg("version"), DOC(dai, OpenVINO, getVersionName))
@@ -24,7 +43,8 @@ void OpenVINOBindings::bind(pybind11::module& m){
     // and that the values are available directly under OpenVINO.VERSION_2021_4, ...
     // they are exported
     // By default, pybind creates strong typed enums, eg: OpenVINO::Version::VERSION_2021_4
-    py::enum_<OpenVINO::Version>(openvino, "Version", DOC(dai, OpenVINO, Version))
+
+    openvinoVersion
         .value("VERSION_2020_3", OpenVINO::Version::VERSION_2020_3)
         .value("VERSION_2020_4", OpenVINO::Version::VERSION_2020_4)
         .value("VERSION_2021_1", OpenVINO::Version::VERSION_2021_1)

--- a/src/openvino/OpenVINOBindings.hpp
+++ b/src/openvino/OpenVINOBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct OpenVINOBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/pipeline/AssetManagerBindings.cpp
+++ b/src/pipeline/AssetManagerBindings.cpp
@@ -3,12 +3,32 @@
 // depthai
 #include "depthai/pipeline/AssetManager.hpp"
 
-void AssetManagerBindings::bind(pybind11::module& m){
+void AssetManagerBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
+
+    // Type definitions
+    py::class_<Asset, std::shared_ptr<Asset>> asset(m, "Asset", DOC(dai, Asset));
+    py::class_<AssetManager> assetManager(m, "AssetManager", DOC(dai, AssetManager));
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+
     // Bind Asset
-    py::class_<Asset, std::shared_ptr<Asset>>(m, "Asset", DOC(dai, Asset))
+    asset
         .def(py::init<>())
         .def(py::init<std::string>())
         .def_readonly("key", &Asset::key)
@@ -23,9 +43,8 @@ void AssetManagerBindings::bind(pybind11::module& m){
         .def_readwrite("alignment", &Asset::alignment)
     ;
 
-
     // Bind AssetManager
-    py::class_<AssetManager>(m, "AssetManager", DOC(dai, AssetManager))
+    assetManager
         .def(py::init<>())
         .def("addExisting", &AssetManager::addExisting, py::arg("assets"), DOC(dai, AssetManager, addExisting))
         .def("set", static_cast<std::shared_ptr<dai::Asset> (AssetManager::*)(Asset)>(&AssetManager::set), py::arg("asset"), DOC(dai, AssetManager, set))

--- a/src/pipeline/AssetManagerBindings.hpp
+++ b/src/pipeline/AssetManagerBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct AssetManagerBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/pipeline/CommonBindings.cpp
+++ b/src/pipeline/CommonBindings.cpp
@@ -14,25 +14,57 @@
 #include "depthai-shared/common/Size2f.hpp"
 #include "depthai-shared/common/UsbSpeed.hpp"
 
-void CommonBindings::bind(pybind11::module& m){
+void CommonBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
-    py::class_<Timestamp>(m, "Timestamp", DOC(dai, Timestamp))
+    py::class_<Timestamp> timestamp(m, "Timestamp", DOC(dai, Timestamp));
+    py::class_<Point2f> point2f(m, "Point2f", DOC(dai, Point2f));
+    py::class_<Point3f> point3f(m, "Point3f", DOC(dai, Point3f));
+    py::class_<Size2f> size2f(m, "Size2f", DOC(dai, Size2f));
+    py::enum_<CameraBoardSocket> cameraBoardSocket(m, "CameraBoardSocket", DOC(dai, CameraBoardSocket));
+    py::enum_<CameraImageOrientation> cameraImageOrientation(m, "CameraImageOrientation", DOC(dai, CameraImageOrientation));
+    py::class_<MemoryInfo> memoryInfo(m, "MemoryInfo", DOC(dai, MemoryInfo));
+    py::class_<ChipTemperature> chipTemperature(m, "ChipTemperature", DOC(dai, ChipTemperature));
+    py::class_<CpuUsage> cpuUsage(m, "CpuUsage", DOC(dai, CpuUsage));
+    py::enum_<CameraModel> cameraModel(m, "CameraModel", DOC(dai, CameraModel));
+    py::class_<StereoRectification> stereoRectification(m, "StereoRectification", DOC(dai, StereoRectification));
+    py::class_<Extrinsics> extrinsics(m, "Extrinsics", DOC(dai, Extrinsics));
+    py::class_<CameraInfo> cameraInfo(m, "CameraInfo", DOC(dai, CameraInfo));
+    py::class_<EepromData> eepromData(m, "EepromData", DOC(dai, EepromData));
+    py::enum_<UsbSpeed> usbSpeed(m, "UsbSpeed", DOC(dai, UsbSpeed));
+    py::enum_<ProcessorType> processorType(m, "ProcessorType");
+
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+
+    timestamp
         .def(py::init<>())
         .def_readwrite("sec", &Timestamp::sec)
         .def_readwrite("nsec", &Timestamp::nsec)
         .def("get", &Timestamp::get)
         ;
 
-    py::class_<Point2f>(m, "Point2f", DOC(dai, Point2f))
+    point2f
         .def(py::init<>())
         .def(py::init<float, float>())
         .def_readwrite("x", &Point2f::x)
         .def_readwrite("y", &Point2f::y)
         ;
 
-    py::class_<Point3f>(m, "Point3f", DOC(dai, Point3f))
+    point3f
         .def(py::init<>())
         .def(py::init<float, float, float>())
         .def_readwrite("x", &Point3f::x)
@@ -40,7 +72,7 @@ void CommonBindings::bind(pybind11::module& m){
         .def_readwrite("z", &Point3f::z)
         ;
 
-    py::class_<Size2f>(m, "Size2f", DOC(dai, Size2f))
+    size2f
         .def(py::init<>())
         .def(py::init<float, float>())
         .def_readwrite("width", &Size2f::width)
@@ -48,7 +80,7 @@ void CommonBindings::bind(pybind11::module& m){
         ;
 
     // CameraBoardSocket enum bindings
-    py::enum_<CameraBoardSocket>(m, "CameraBoardSocket", DOC(dai, CameraBoardSocket))
+    cameraBoardSocket
         .value("AUTO", CameraBoardSocket::AUTO)
         .value("RGB", CameraBoardSocket::RGB)
         .value("LEFT", CameraBoardSocket::LEFT)
@@ -56,7 +88,7 @@ void CommonBindings::bind(pybind11::module& m){
     ;
 
     // CameraImageOrientation enum bindings
-    py::enum_<CameraImageOrientation>(m, "CameraImageOrientation", DOC(dai, CameraImageOrientation))
+    cameraImageOrientation
         .value("AUTO", CameraImageOrientation::AUTO)
         .value("NORMAL", CameraImageOrientation::NORMAL)
         .value("HORIZONTAL_MIRROR", CameraImageOrientation::HORIZONTAL_MIRROR)
@@ -65,7 +97,7 @@ void CommonBindings::bind(pybind11::module& m){
     ;
 
     // MemoryInfo
-    py::class_<MemoryInfo>(m, "MemoryInfo", DOC(dai, MemoryInfo))
+    memoryInfo
         .def(py::init<>())
         .def_readwrite("remaining", &MemoryInfo::remaining)
         .def_readwrite("used", &MemoryInfo::used)
@@ -73,7 +105,7 @@ void CommonBindings::bind(pybind11::module& m){
     ;
 
     // ChipTemperature
-    py::class_<ChipTemperature>(m, "ChipTemperature", DOC(dai, ChipTemperature))
+    chipTemperature
         .def(py::init<>())
         .def_readwrite("css", &ChipTemperature::css)
         .def_readwrite("mss", &ChipTemperature::mss)
@@ -83,13 +115,13 @@ void CommonBindings::bind(pybind11::module& m){
     ;
 
     // CpuUsage
-    py::class_<CpuUsage>(m, "CpuUsage", DOC(dai, CpuUsage))
+    cpuUsage
         .def(py::init<>())
         .def_readwrite("average", &CpuUsage::average)
         .def_readwrite("msTime", &CpuUsage::msTime)
     ;
     // CameraModel enum bindings
-    py::enum_<CameraModel>(m, "CameraModel", DOC(dai, CameraModel))
+    cameraModel
         .value("Perspective", CameraModel::Perspective)
         .value("Fisheye", CameraModel::Fisheye)
         .value("Equirectangular", CameraModel::Equirectangular)
@@ -97,7 +129,7 @@ void CommonBindings::bind(pybind11::module& m){
     ;
 
     // StereoRectification
-    py::class_<StereoRectification> (m, "StereoRectification", DOC(dai, StereoRectification))
+    stereoRectification
         .def(py::init<>())
         .def_readwrite("rectifiedRotationLeft", &StereoRectification::rectifiedRotationLeft)
         .def_readwrite("rectifiedRotationRight", &StereoRectification::rectifiedRotationRight)
@@ -106,7 +138,7 @@ void CommonBindings::bind(pybind11::module& m){
         ;
 
     // Extrinsics
-    py::class_<Extrinsics> (m, "Extrinsics", DOC(dai, Extrinsics))
+    extrinsics
         .def(py::init<>())
         .def_readwrite("rotationMatrix", &Extrinsics::rotationMatrix)
         .def_readwrite("translation", &Extrinsics::translation)
@@ -115,7 +147,7 @@ void CommonBindings::bind(pybind11::module& m){
         ;
 
     // CameraInfo
-    py::class_<CameraInfo> (m, "CameraInfo", DOC(dai, CameraInfo))
+    cameraInfo
         .def(py::init<>())
         .def_readwrite("width", &CameraInfo::width)
         .def_readwrite("height", &CameraInfo::height)
@@ -127,7 +159,7 @@ void CommonBindings::bind(pybind11::module& m){
         ;
 
     // EepromData
-    py::class_<EepromData> (m, "EepromData", DOC(dai, EepromData))
+    eepromData
         .def(py::init<>())
         .def_readwrite("version", &EepromData::version)
         .def_readwrite("boardName", &EepromData::boardName)
@@ -137,7 +169,7 @@ void CommonBindings::bind(pybind11::module& m){
         .def_readwrite("imuExtrinsics", &EepromData::imuExtrinsics)
         ;
     // UsbSpeed
-    py::enum_<UsbSpeed>(m, "UsbSpeed", DOC(dai, UsbSpeed))
+    usbSpeed
         .value("UNKNOWN", UsbSpeed::UNKNOWN)
         .value("LOW", UsbSpeed::LOW)
         .value("FULL", UsbSpeed::FULL)
@@ -147,7 +179,7 @@ void CommonBindings::bind(pybind11::module& m){
     ;
 
     // ProcessorType
-    py::enum_<ProcessorType>(m, "ProcessorType")
+    processorType
         .value("LEON_CSS", ProcessorType::LEON_CSS)
         .value("LEON_MSS", ProcessorType::LEON_MSS)
     ;

--- a/src/pipeline/CommonBindings.hpp
+++ b/src/pipeline/CommonBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct CommonBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/pipeline/NodeBindings.hpp
+++ b/src/pipeline/NodeBindings.hpp
@@ -7,6 +7,6 @@
 #include "depthai/pipeline/Node.hpp"
 
 struct NodeBindings : public dai::Node {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
     static std::vector<std::pair<py::handle, std::function<std::shared_ptr<dai::Node>(dai::Pipeline&, py::object class_)>>> getNodeCreateMap();
 };

--- a/src/pipeline/PipelineBindings.cpp
+++ b/src/pipeline/PipelineBindings.cpp
@@ -42,13 +42,29 @@ std::shared_ptr<dai::Node> createNode(dai::Pipeline& p, py::object class_){
     return nullptr;
 }
 
-void PipelineBindings::bind(pybind11::module& m){
-
+void PipelineBindings::bind(pybind11::module& m, void* pCallstack){
     using namespace dai;
+
+    // Type definitions
+    py::class_<GlobalProperties> globalProperties(m, "GlobalProperties", DOC(dai, GlobalProperties));
+    py::class_<Pipeline> pipeline(m, "Pipeline", DOC(dai, Pipeline, 2));
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
 
 
     // Bind global properties
-    py::class_<GlobalProperties>(m, "GlobalProperties", DOC(dai, GlobalProperties))
+    globalProperties
         .def_readwrite("leonOsFrequencyHz", &GlobalProperties::leonCssFrequencyHz)
         .def_readwrite("leonRtFrequencyHz", &GlobalProperties::leonMssFrequencyHz)
         .def_readwrite("pipelineName", &GlobalProperties::pipelineName)
@@ -58,7 +74,7 @@ void PipelineBindings::bind(pybind11::module& m){
         ;
 
     // bind pipeline
-    py::class_<Pipeline>(m, "Pipeline", DOC(dai, Pipeline, 2))
+    pipeline
         .def(py::init<>(), DOC(dai, Pipeline, Pipeline))
         //.def(py::init<const Pipeline&>())
         .def("getGlobalProperties", &Pipeline::getGlobalProperties, DOC(dai, Pipeline, getGlobalProperties))
@@ -110,5 +126,6 @@ void PipelineBindings::bind(pybind11::module& m){
         .def("createIMU", &Pipeline::create<node::IMU>)
         .def("createEdgeDetector", &Pipeline::create<node::EdgeDetector>)
         ;
+
 
 }

--- a/src/pipeline/PipelineBindings.hpp
+++ b/src/pipeline/PipelineBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct PipelineBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/py_bindings.cpp
+++ b/src/py_bindings.cpp
@@ -39,18 +39,25 @@ PYBIND11_MODULE(depthai,m)
     m.attr("__build_datetime__") = DEPTHAI_PYTHON_BUILD_DATETIME;
 
     // Add bindings
-    CommonBindings::bind(m);
-    DatatypeBindings::bind(m);
-    LogBindings::bind(m);
-    DataQueueBindings::bind(m);
-    OpenVINOBindings::bind(m);
-    AssetManagerBindings::bind(m);
-    PipelineBindings::bind(m);
-    NodeBindings::bind(m);
-    XLinkConnectionBindings::bind(m);
-    DeviceBindings::bind(m);
-    DeviceBootloaderBindings::bind(m);
-    CalibrationHandlerBindings::bind(m);
+    std::deque<StackFunction> callstack;
+    callstack.push_front(&DatatypeBindings::bind);
+    callstack.push_front(&LogBindings::bind);
+    callstack.push_front(&DataQueueBindings::bind);
+    callstack.push_front(&OpenVINOBindings::bind);
+    callstack.push_front(&AssetManagerBindings::bind);
+    callstack.push_front(&NodeBindings::bind);
+    callstack.push_front(&PipelineBindings::bind);
+    callstack.push_front(&XLinkConnectionBindings::bind);
+    callstack.push_front(&DeviceBindings::bind);
+    callstack.push_front(&DeviceBootloaderBindings::bind);
+    callstack.push_front(&CalibrationHandlerBindings::bind);
+    // end of the callstack
+    callstack.push_front([](py::module&, void*){});
+
+    Callstack callstackAdapter(callstack);
+
+    // Initial call
+    CommonBindings::bind(m, &callstackAdapter);
 
     // Call dai::initialize on 'import depthai' to initialize asap with additional information to print
     dai::initialize(std::string("Python bindings - version: ") + DEPTHAI_PYTHON_VERSION + " from " + DEPTHAI_PYTHON_COMMIT_DATETIME + " build: " + DEPTHAI_PYTHON_BUILD_DATETIME);

--- a/src/pybind11_common.hpp
+++ b/src/pybind11_common.hpp
@@ -10,6 +10,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/numpy.h>
 #include <cstdint>
+#include <stack>
 
 // Include docstring file
 #include "docstring.hpp"
@@ -24,4 +25,6 @@ namespace pybind11 { namespace detail {
 
 namespace py = pybind11;
 
+using StackFunction = void (*)(pybind11::module &m, void *pCallstack);
+using Callstack = std::stack<StackFunction>;
 

--- a/src/utility/ResourcesBindings.cpp
+++ b/src/utility/ResourcesBindings.cpp
@@ -3,13 +3,13 @@
 // depthai
 // include resources #include "depthai/"
 
-void ResourcesBindings::bind(pybind11::module& m){
+void ResourcesBindings::bind(pybind11::module& m, void* pCallstack){
 
     using namespace dai;
 
     // Bind Resources (if needed)
     py::class_<Resources, std::unique_ptr<Resources, py::nodelete>>(m, "Resources")
-    .def(py::init([](){ 
+    .def(py::init([](){
         return std::unique_ptr<Resources, py::nodelete>>(&Resources::getInstance());
     });
 

--- a/src/utility/ResourcesBindings.hpp
+++ b/src/utility/ResourcesBindings.hpp
@@ -4,5 +4,5 @@
 #include "pybind11_common.hpp"
 
 struct ResourcesBindings {
-    static void bind(pybind11::module& m);
+    static void bind(pybind11::module& m, void* pCallstack);
 };


### PR DESCRIPTION
Adds a two stage binding mechanism - this allows `pybind11` to correctly resolve all types for function signatures.

Fixes the issue of Python reference showing C++ types without links (for all cases)
Before:
![image](https://user-images.githubusercontent.com/16122143/126850301-7ef2b820-d2e4-4a1c-ae48-6ac650077e01.png)

After:

![image](https://user-images.githubusercontent.com/16122143/126850401-a8d616fe-9a0e-4ac3-b5be-c9b29cc657b2.png)

