### PR TITLE
Add option to pick spatial calculation algorithm : average,min,max of…

### DIFF
--- a/examples/spatial_location_calculator.py
+++ b/examples/spatial_location_calculator.py
@@ -125,6 +125,7 @@ with dai.Device(pipeline) as device:
 
         if newConfig:
             config.roi = dai.Rect(topLeft, bottomRight)
+            config.calculationAlgorithm = dai.SpatialLocationCalculatorAlgorithm.AVERAGE
             cfg = dai.SpatialLocationCalculatorConfig()
             cfg.addROI(config)
             spatialCalcConfigInQueue.send(cfg)

--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -100,6 +100,7 @@ void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
     py::class_<SpatialLocations> spatialLocations(m, "SpatialLocations", DOC(dai, SpatialLocations));
     py::class_<Rect> rect(m, "Rect", DOC(dai, Rect));
     py::class_<SpatialLocationCalculatorConfigThresholds> spatialLocationCalculatorConfigThresholds(m, "SpatialLocationCalculatorConfigThresholds", DOC(dai, SpatialLocationCalculatorConfigThresholds));
+    py::enum_<SpatialLocationCalculatorAlgorithm> spatialLocationCalculatorAlgorithm(m, "SpatialLocationCalculatorAlgorithm", DOC(dai, SpatialLocationCalculatorAlgorithm));
     py::class_<SpatialLocationCalculatorConfigData> spatialLocationCalculatorConfigData(m, "SpatialLocationCalculatorConfigData", DOC(dai, SpatialLocationCalculatorConfigData));
     py::class_<SpatialLocationCalculatorData, Buffer, std::shared_ptr<SpatialLocationCalculatorData>> spatialLocationCalculatorData(m, "SpatialLocationCalculatorData", DOC(dai, SpatialLocationCalculatorData));
     py::class_<SpatialLocationCalculatorConfig, Buffer, std::shared_ptr<SpatialLocationCalculatorConfig>> spatialLocationCalculatorConfig(m, "SpatialLocationCalculatorConfig", DOC(dai, SpatialLocationCalculatorConfig));
@@ -990,11 +991,17 @@ void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
         .def_readwrite("upperThreshold", &SpatialLocationCalculatorConfigThresholds::upperThreshold)
         ;
 
+    spatialLocationCalculatorAlgorithm
+        .value("AVERAGE", SpatialLocationCalculatorAlgorithm::AVERAGE)
+        .value("MIN", SpatialLocationCalculatorAlgorithm::MIN)
+        .value("MAX", SpatialLocationCalculatorAlgorithm::MAX)
+        ;
 
     spatialLocationCalculatorConfigData
         .def(py::init<>())
-        .def_readwrite("roi", &SpatialLocationCalculatorConfigData::roi)
-        .def_readwrite("depthThresholds", &SpatialLocationCalculatorConfigData::depthThresholds)
+        .def_readwrite("roi", &SpatialLocationCalculatorConfigData::roi, DOC(dai, SpatialLocationCalculatorConfigData, roi))
+        .def_readwrite("depthThresholds", &SpatialLocationCalculatorConfigData::depthThresholds, DOC(dai, SpatialLocationCalculatorConfigData, depthThresholds))
+        .def_readwrite("calculationAlgorithm", &SpatialLocationCalculatorConfigData::calculationAlgorithm, DOC(dai, SpatialLocationCalculatorConfigData, calculationAlgorithm))
         ;
 
     // Bind SpatialLocationCalculatorData

--- a/src/pipeline/NodeBindings.cpp
+++ b/src/pipeline/NodeBindings.cpp
@@ -944,6 +944,7 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         .def("setBoundingBoxScaleFactor", &SpatialDetectionNetwork::setBoundingBoxScaleFactor, py::arg("scaleFactor"), DOC(dai, node, SpatialDetectionNetwork, setBoundingBoxScaleFactor))
         .def("setDepthLowerThreshold", &SpatialDetectionNetwork::setDepthLowerThreshold, py::arg("lowerThreshold"), DOC(dai, node, SpatialDetectionNetwork, setDepthLowerThreshold))
         .def("setDepthUpperThreshold", &SpatialDetectionNetwork::setDepthUpperThreshold, py::arg("upperThreshold"), DOC(dai, node, SpatialDetectionNetwork, setDepthUpperThreshold))
+        .def("setSpatialCalculationAlgorithm", &SpatialDetectionNetwork::setSpatialCalculationAlgorithm, py::arg("calculationAlgorithm"), DOC(dai, node, SpatialDetectionNetwork, setSpatialCalculationAlgorithm))
         ;
      // ALIAS
     daiNodeModule.attr("SpatialDetectionNetwork").attr("Properties") = spatialDetectionNetworkProperties;


### PR DESCRIPTION
… selected ROI.
Related PR:
https://github.com/luxonis/depthai-core/pull/213

Example to change mode:
https://github.com/luxonis/depthai-python/blob/spatial_calc_algo_choice/examples/spatial_location_calculator.py#L128
Change from:
`dai.SpatialLocationCalculatorAlgorithm.AVERAGE`
to:
`dai.SpatialLocationCalculatorAlgorithm.MIN`
