### PR TITLE
Build wheels for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
         python-architecture: [x64, x86]
     steps:
       - name: Cache .hunter folder
@@ -159,7 +159,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
     steps:
       - name: Cache .hunter folder
         uses: actions/cache@v2

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: C++",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
CI passing: https://github.com/luxonis/depthai-python/actions/runs/1328896211

However the usage could be limited at the moment, prebuilts for `numpy` and `opencv-python` don't seem to be available yet.