### PR TITLE
Modified setBlobPath for better blobconverter integration

### DIFF
--- a/src/pipeline/NodeBindings.cpp
+++ b/src/pipeline/NodeBindings.cpp
@@ -626,7 +626,10 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         .def_readonly("input", &NeuralNetwork::input, DOC(dai, node, NeuralNetwork, input))
         .def_readonly("out", &NeuralNetwork::out, DOC(dai, node, NeuralNetwork, out))
         .def_readonly("passthrough", &NeuralNetwork::passthrough, DOC(dai, node, NeuralNetwork, passthrough))
-        .def("setBlobPath", &NeuralNetwork::setBlobPath, py::arg("path"), DOC(dai, node, NeuralNetwork, setBlobPath))
+        .def("setBlobPath", [](NeuralNetwork& nn, py::object obj){
+            // Allows to call this function with paths as well as strings
+            nn.setBlobPath(py::str(obj));
+        }, py::arg("path"), DOC(dai, node, NeuralNetwork, setBlobPath))
         .def("setNumPoolFrames", &NeuralNetwork::setNumPoolFrames, py::arg("numFrames"), DOC(dai, node, NeuralNetwork, setNumPoolFrames))
         .def("setNumInferenceThreads", &NeuralNetwork::setNumInferenceThreads, py::arg("numThreads"), DOC(dai, node, NeuralNetwork, setNumInferenceThreads))
         .def("setNumNCEPerInferenceThread", &NeuralNetwork::setNumNCEPerInferenceThread, py::arg("numNCEPerThread"), DOC(dai, node, NeuralNetwork, setNumNCEPerInferenceThread))


### PR DESCRIPTION
Allows accepting any py object and tries converting to string internally.

From:
```
nn.setBlobPath(str(blobconverter.from_zoo("face-detection-retail-0004")))
```

To:
```
nn.setBlobPath(blobconverter.from_zoo("face-detection-retail-0004"))
```

If called with any other objects, it will either call C++ setBlobPath if str() exists, and error out that no blob can be found at that path, or error out on Python end, to not being able to convert to string (not sure if that can even be the case)