### PR TITLE
Restrict opencv-python version

### DIFF
--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -53,6 +53,7 @@ if thisPlatform == "aarch64":
 
 if requireOpenCv:
     DEPENDENCIES.append('numpy')
+    # 4.5.4.58 package is broken for python 3.9
     if sys.version_info[1] == '9':
         DEPENDENCIES.append('opencv-python!=4.5.4.58')
     else:

--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -52,7 +52,12 @@ if thisPlatform == "aarch64":
         requireOpenCv = True
 
 if requireOpenCv:
-    DEPENDENCIES.extend(['numpy','opencv-python'])
+    DEPENDENCIES.append('numpy')
+    if sys.version_info[1] == '9':
+        DEPENDENCIES.append('opencv-python!=4.5.4.58')
+    else:
+        DEPENDENCIES.append('opencv-python')
+
 
 
 # Constants

--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -54,7 +54,7 @@ if thisPlatform == "aarch64":
 if requireOpenCv:
     DEPENDENCIES.append('numpy')
     # 4.5.4.58 package is broken for python 3.9
-    if sys.version_info[1] == '9':
+    if sys.version_info[0] == 3 and sys.version_info[1] == 9:
         DEPENDENCIES.append('opencv-python!=4.5.4.58')
     else:
         DEPENDENCIES.append('opencv-python')


### PR DESCRIPTION
Reason: `4.5.4.58` is broken on python3.9.