### PR TITLE
Read bootloader config json now returns valid json

### DIFF
--- a/examples/bootloader/bootloader_config.py
+++ b/examples/bootloader/bootloader_config.py
@@ -2,6 +2,7 @@
 
 import depthai as dai
 import sys
+import json
 
 usage = False
 read = True
@@ -34,7 +35,7 @@ if res:
     with dai.DeviceBootloader(info) as bl:
         if read:
             print('Current flashed configuration')
-            print(f'{bl.readConfigData()}')
+            print(json.dumps(bl.readConfigData()))
         else:
             success = None
             error = None


### PR DESCRIPTION
Now `bootlaoder_config.py read` returns valid json:
```
{"appMem": -1, "network": {"ipv4": 0, "ipv4Dns": 0, "ipv4DnsAlt": 0, "ipv4Gateway": 0, "ipv4Mask": 0, "ipv6": [0, 0, 0, 0], "ipv6Dns": [0, 0, 0, 0], "ipv6DnsAlt": [0, 0, 0, 0], "ipv6Gateway": [0, 0, 0, 0], "ipv6Prefix": 0, "mac": [0, 0, 0, 0, 0, 0], "staticIpv4": false, "staticIpv6": false, "timeoutMs": 30000}, "usb": {"maxUsbSpeed": 3, "pid": 63036, "timeoutMs": 3000, "vid": 999}}
```