### PR TITLE
Hello world docs page usb2Mode capitalization typo.

### DIFF
--- a/docs/source/tutorials/hello_world.rst
+++ b/docs/source/tutorials/hello_world.rst
@@ -164,7 +164,7 @@ Having the pipeline defined, we can now initialize a device with pipeline and st
 
   .. code-block:: python
 
-    device = depthai.Device(pipeline, usb2mode=True)
+    device = depthai.Device(pipeline, usb2Mode=True)
 
 
 


### PR DESCRIPTION
The hello world doc page says to use "usb2mode" with no capitalization; this throws an error, with the correct argument name being "usb2Mode".

Page: https://docs.luxonis.com/projects/api/en/latest/tutorials/hello_world/#initialize-the-depthai-device

![image](https://user-images.githubusercontent.com/12007568/146860161-e7c3722b-b17c-4ac5-ae30-5a880920a874.png)

![image](https://user-images.githubusercontent.com/12007568/146860196-63905d30-be07-47d5-89df-4c2cb610dcef.png)

