### PR TITLE
Install dependencies tweaks

### DIFF
--- a/docs/source/_static/install_dependencies.sh
+++ b/docs/source/_static/install_dependencies.sh
@@ -127,7 +127,7 @@ elif [ -f /etc/os-release ]; then
         UVC_DYN_INSTALLED=$(dpkg-query -W --showformat='${Status}\n' uvcdynctrl|grep "install ok installed")
         if [ "" != "$UVC_DYN_INSTALLED" ]; then
           echo -e "\033[33mWe detected \"uvcdynctrl\" installed on your system. \033[0m"
-          echo -e "\033[33mWe recommend to remove this package, as it creates a huge log files if a camera is used in UVC mode (webcam)\033[0m"
+          echo -e "\033[33mWe recommend removing this package, as it creates a huge log files if a camera is used in UVC mode (webcam)\033[0m"
           echo -e "\033[33mYou can do so by running the following commands:\033[0m"
           echo -e "\033[33m$ sudo apt remove uvcdynctrl uvcdynctrl-data\033[0m"
           echo -e "\033[33m$ sudo rm -f /var/log/uvcdynctrl-udev.log\033[0m"
@@ -137,7 +137,7 @@ elif [ -f /etc/os-release ]; then
         OS_VERSION=$(lsb_release -r |cut -f2)
         if [ "$OS_VERSION" == "21.04" ]; then
             echo -e "\033[33mThere are known issues with running our demo script on Ubuntu 21.04, due to package \"python3-pyqt5.sip\" not being in a correct version (>=12.9)\033[0m"
-            echo -e "\033[33mWe recommend to install the updated version manually using the following commands\033[0m"
+            echo -e "\033[33mWe recommend installing the updated version manually using the following commands\033[0m"
             echo -e "\033[33m$ wget http://mirrors.kernel.org/ubuntu/pool/universe/p/pyqt5-sip/python3-pyqt5.sip_12.9.0-1_amd64.deb\033[0m"
             echo -e "\033[33m$ sudo dpkg -i python3-pyqt5.sip_12.9.0-1_amd64.deb\033[0m"
             echo ""

--- a/docs/source/_static/install_dependencies.sh
+++ b/docs/source/_static/install_dependencies.sh
@@ -126,20 +126,20 @@ elif [ -f /etc/os-release ]; then
 
         UVC_DYN_INSTALLED=$(dpkg-query -W --showformat='${Status}\n' uvcdynctrl|grep "install ok installed")
         if [ "" != "$UVC_DYN_INSTALLED" ]; then
-          echo "We detected \"uvcdynctrl\" installed on your system. "
-          echo "We recommend to remove this package, as it creates a huge log files if a camera is used in UVC mode (webcam)"
-          echo "You can do so by running the following commands:"
-          echo "$ sudo apt remove uvcdynctrl"
-          echo "$ sudo rm -f /var/log/uvcdynctrl-udev.log"
+          echo -e "\033[33mWe detected \"uvcdynctrl\" installed on your system. \033[0m"
+          echo -e "\033[33mWe recommend to remove this package, as it creates a huge log files if a camera is used in UVC mode (webcam)\033[0m"
+          echo -e "\033[33mYou can do so by running the following commands:\033[0m"
+          echo -e "\033[33m$ sudo apt remove uvcdynctrl uvcdynctrl-data\033[0m"
+          echo -e "\033[33m$ sudo rm -f /var/log/uvcdynctrl-udev.log\033[0m"
           echo ""
         fi
 
         OS_VERSION=$(lsb_release -r |cut -f2)
         if [ "$OS_VERSION" == "21.04" ]; then
-            echo "There are known issues with running our demo script on Ubuntu 21.04, due to package \"python3-pyqt5.sip\" not being in a correct version (>=12.9)"
-            echo "We recommend to install the updated version manually using the following commands"
-            echo "$ wget http://mirrors.kernel.org/ubuntu/pool/universe/p/pyqt5-sip/python3-pyqt5.sip_12.9.0-1_amd64.deb"
-            echo "$ sudo dpkg -i python3-pyqt5.sip_12.9.0-1_amd64.deb"
+            echo -e "\033[33mThere are known issues with running our demo script on Ubuntu 21.04, due to package \"python3-pyqt5.sip\" not being in a correct version (>=12.9)\033[0m"
+            echo -e "\033[33mWe recommend to install the updated version manually using the following commands\033[0m"
+            echo -e "\033[33m$ wget http://mirrors.kernel.org/ubuntu/pool/universe/p/pyqt5-sip/python3-pyqt5.sip_12.9.0-1_amd64.deb\033[0m"
+            echo -e "\033[33m$ sudo dpkg -i python3-pyqt5.sip_12.9.0-1_amd64.deb\033[0m"
             echo ""
         fi
     elif [[ "$ID" == "fedora" ]]; then

--- a/docs/source/_static/install_dependencies.sh
+++ b/docs/source/_static/install_dependencies.sh
@@ -123,6 +123,25 @@ elif [ -f /etc/os-release ]; then
             sudo apt-get install -y "${ubuntu_arm_pkgs[@]}"
             python3 -m pip install --upgrade pip
         fi
+
+        UVC_DYN_INSTALLED=$(dpkg-query -W --showformat='${Status}\n' uvcdynctrl|grep "install ok installed")
+        if [ "" != "$UVC_DYN_INSTALLED" ]; then
+          echo "We detected \"uvcdynctrl\" installed on your system. "
+          echo "We recommend to remove this package, as it creates a huge log files if a camera is used in UVC mode (webcam)"
+          echo "You can do so by running the following commands:"
+          echo "$ sudo apt remove uvcdynctrl"
+          echo "$ sudo rm -f /var/log/uvcdynctrl-udev.log"
+          echo ""
+        fi
+
+        OS_VERSION=$(lsb_release -r |cut -f2)
+        if [ "$OS_VERSION" == "21.04" ]; then
+            echo "There are known issues with running our demo script on Ubuntu 21.04, due to package \"python3-pyqt5.sip\" not being in a correct version (>=12.9)"
+            echo "We recommend to install the updated version manually using the following commands"
+            echo "$ wget http://mirrors.kernel.org/ubuntu/pool/universe/p/pyqt5-sip/python3-pyqt5.sip_12.9.0-1_amd64.deb"
+            echo "$ sudo dpkg -i python3-pyqt5.sip_12.9.0-1_amd64.deb"
+            echo ""
+        fi
     elif [[ "$ID" == "fedora" ]]; then
         sudo dnf update -y
         sudo dnf install -y "${fedora_pkgs[@]}"


### PR DESCRIPTION
This PR adds checks for both `uvcdynctrl` package that should be removed and for Ubuntu 21.04, that has issues with one of the Qt dependencies