### PR TITLE
Fix swapped width and height parameters in reshape function

### DIFF
--- a/examples/ColorCamera/rgb_camera_control.py
+++ b/examples/ColorCamera/rgb_camera_control.py
@@ -103,7 +103,7 @@ with dai.Device(pipeline) as device:
     while True:
         previewFrames = previewQueue.tryGetAll()
         for previewFrame in previewFrames:
-            cv2.imshow('preview', previewFrame.getData().reshape(previewFrame.getWidth(), previewFrame.getHeight(), 3))
+            cv2.imshow('preview', previewFrame.getData().reshape(previewFrame.getHeight(), previewFrame.getWidth(), 3))
 
         videoFrames = videoQueue.tryGetAll()
         for videoFrame in videoFrames:


### PR DESCRIPTION
By default, the width is equal to the height, so things worked anyway, but the preview image will be garbled when the size is changed to anything non-square here: https://github.com/luxonis/depthai-python/blob/eba227ac1a865229aaf587c992b1f3619827abf9/examples/ColorCamera/rgb_camera_control.py#L54

As best practice, it might be a good idea to not use square shapes so this error would have been more obvious.