### PR TITLE
Use focal length from calibration intrinsics for fisheye cameras

### DIFF
--- a/examples/StereoDepth/stereo_depth_video.py
+++ b/examples/StereoDepth/stereo_depth_video.py
@@ -205,7 +205,6 @@ stereo.setDefaultProfilePreset(dai.node.StereoDepth.PresetMode.HIGH_DENSITY)
 stereo.initialConfig.setMedianFilter(median)  # KERNEL_7x7 default
 stereo.setRectifyEdgeFillColor(0)  # Black, to better see the cutout
 stereo.setLeftRightCheck(lrcheck)
-# FIXME: RuntimeError: StereoDepth(2) - StereoDepth | ExtendedDisparity is not implemented yet.
 stereo.setExtendedDisparity(extended)
 stereo.setSubpixel(subpixel)
 

--- a/src/pipeline/NodeBindings.cpp
+++ b/src/pipeline/NodeBindings.cpp
@@ -922,6 +922,7 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         }, DOC(dai, node, StereoDepth, getMaxDisparity))
         .def("setPostProcessingHardwareResources", &StereoDepth::setPostProcessingHardwareResources, DOC(dai, node, StereoDepth, setPostProcessingHardwareResources))
         .def("setDefaultProfilePreset", &StereoDepth::setDefaultProfilePreset, DOC(dai, node, StereoDepth, setDefaultProfilePreset))
+        .def("setFocalLengthFromCalibration", &StereoDepth::setFocalLengthFromCalibration, DOC(dai, node, StereoDepth, setFocalLengthFromCalibration))
         ;
     // ALIAS
     daiNodeModule.attr("StereoDepth").attr("Properties") = stereoDepthProperties;


### PR DESCRIPTION
Use focal length from intrinsics for fisheye lenses.
Can be explicitly overridden: `setFocalLengthFromCalibration(bool)`
Related PR: https://github.com/luxonis/depthai-core/pull/350