### PR TITLE
Add latest manifest creation

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -92,4 +92,9 @@ jobs:
           --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-armv8
           # Push
           docker manifest push luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}
+          docker manifest create \
+          luxonis/depthai-library:latest \
+          --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-amd64 \
+          --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-armv7 \
+          --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-armv8
           docker manifest push luxonis/depthai-library:latest


### PR DESCRIPTION
Currently, our `latest` tag on dockerhub is outdated, and is not updated due to a missing latest manifest creation in pipeline - see error here https://github.com/luxonis/depthai-python/runs/4724751515?check_suite_focus=true

This PR adds the latest manifest creation before push