### PR TITLE
Customizable depth unit

### DIFF
--- a/docs/source/components/nodes/stereo_depth.rst
+++ b/docs/source/components/nodes/stereo_depth.rst
@@ -56,7 +56,7 @@ Inputs and Outputs
     - :code:`confidenceMap` - :ref:`ImgFrame`
     - :code:`rectifiedLeft` - :ref:`ImgFrame`
     - :code:`syncedLeft` - :ref:`ImgFrame`
-    - :code:`depth` - :ref:`ImgFrame`: UINT16 values - depth in depth units (millimetre by default)
+    - :code:`depth` - :ref:`ImgFrame`: UINT16 values - depth in depth units (millimeter by default)
     - :code:`disparity` - :ref:`ImgFrame`: UINT8 or UINT16 if Subpixel mode
     - :code:`rectifiedRight` - :ref:`ImgFrame`
     - :code:`syncedRight` - :ref:`ImgFrame`

--- a/docs/source/components/nodes/stereo_depth.rst
+++ b/docs/source/components/nodes/stereo_depth.rst
@@ -56,7 +56,7 @@ Inputs and Outputs
     - :code:`confidenceMap` - :ref:`ImgFrame`
     - :code:`rectifiedLeft` - :ref:`ImgFrame`
     - :code:`syncedLeft` - :ref:`ImgFrame`
-    - :code:`depth` - :ref:`ImgFrame`: UINT16 values - depth in millimeters
+    - :code:`depth` - :ref:`ImgFrame`: UINT16 values - depth in depth units (millimetre by default)
     - :code:`disparity` - :ref:`ImgFrame`: UINT8 or UINT16 if Subpixel mode
     - :code:`rectifiedRight` - :ref:`ImgFrame`
     - :code:`syncedRight` - :ref:`ImgFrame`

--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -116,6 +116,7 @@ void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
     py::enum_<MedianFilter> medianFilter(m, "MedianFilter", DOC(dai, MedianFilter));
     py::class_<RawStereoDepthConfig::AlgorithmControl> algorithmControl(rawStereoDepthConfig, "AlgorithmControl", DOC(dai, RawStereoDepthConfig, AlgorithmControl));
     py::enum_<RawStereoDepthConfig::AlgorithmControl::DepthAlign> depthAlign(algorithmControl, "DepthAlign", DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthAlign));
+    py::enum_<RawStereoDepthConfig::AlgorithmControl::DepthUnit> depthUnit(algorithmControl, "DepthUnit", DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthUnit));
     py::class_<RawStereoDepthConfig::PostProcessing> postProcessing(rawStereoDepthConfig, "PostProcessing", DOC(dai, RawStereoDepthConfig, PostProcessing));
     py::class_<RawStereoDepthConfig::PostProcessing::SpatialFilter> spatialFilter(postProcessing, "SpatialFilter", DOC(dai, RawStereoDepthConfig, PostProcessing, SpatialFilter));
     py::class_<RawStereoDepthConfig::PostProcessing::TemporalFilter> temporalFilter(postProcessing, "TemporalFilter", DOC(dai, RawStereoDepthConfig, PostProcessing, TemporalFilter));
@@ -1225,9 +1226,20 @@ void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
 
     m.attr("StereoDepthProperties").attr("DepthAlign") = depthAlign;
 
+    depthUnit
+        .value("METRE", RawStereoDepthConfig::AlgorithmControl::DepthUnit::METRE, DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthUnit, METRE))
+        .value("CENTIMETRE", RawStereoDepthConfig::AlgorithmControl::DepthUnit::CENTIMETRE, DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthUnit, CENTIMETRE))
+        .value("MILLIMETRE", RawStereoDepthConfig::AlgorithmControl::DepthUnit::MILLIMETRE, DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthUnit, MILLIMETRE))
+        .value("INCH", RawStereoDepthConfig::AlgorithmControl::DepthUnit::INCH, DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthUnit, INCH))
+        .value("FOOT", RawStereoDepthConfig::AlgorithmControl::DepthUnit::FOOT, DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthUnit, FOOT))
+        .value("CUSTOM", RawStereoDepthConfig::AlgorithmControl::DepthUnit::CUSTOM, DOC(dai, RawStereoDepthConfig, AlgorithmControl, DepthUnit, CUSTOM))
+        ;
+
     algorithmControl
         .def(py::init<>())
         .def_readwrite("depthAlign", &RawStereoDepthConfig::AlgorithmControl::depthAlign, DOC(dai, RawStereoDepthConfig, AlgorithmControl, depthAlign))
+        .def_readwrite("depthUnit", &RawStereoDepthConfig::AlgorithmControl::depthUnit, DOC(dai, RawStereoDepthConfig, AlgorithmControl, depthUnit))
+        .def_readwrite("customDepthUnitMultiplier", &RawStereoDepthConfig::AlgorithmControl::customDepthUnitMultiplier, DOC(dai, RawStereoDepthConfig, AlgorithmControl, customDepthUnitMultiplier))
         .def_readwrite("enableLeftRightCheck", &RawStereoDepthConfig::AlgorithmControl::enableLeftRightCheck, DOC(dai, RawStereoDepthConfig, AlgorithmControl, enableLeftRightCheck))
         .def_readwrite("enableExtended", &RawStereoDepthConfig::AlgorithmControl::enableExtended, DOC(dai, RawStereoDepthConfig, AlgorithmControl, enableExtended))
         .def_readwrite("enableSubpixel", &RawStereoDepthConfig::AlgorithmControl::enableSubpixel, DOC(dai, RawStereoDepthConfig, AlgorithmControl, enableSubpixel))

--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -1386,6 +1386,8 @@ void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
         .def("setExtendedDisparity",    &StereoDepthConfig::setExtendedDisparity, py::arg("enable"), DOC(dai, StereoDepthConfig, setExtendedDisparity))
         .def("setSubpixel",             &StereoDepthConfig::setSubpixel, py::arg("enable"), DOC(dai, StereoDepthConfig, setSubpixel))
         .def("getMaxDisparity",         &StereoDepthConfig::getMaxDisparity, DOC(dai, StereoDepthConfig, getMaxDisparity))
+        .def("setDepthUnit",            &StereoDepthConfig::setDepthUnit, DOC(dai, StereoDepthConfig, setDepthUnit))
+        .def("getDepthUnit",            &StereoDepthConfig::getDepthUnit, DOC(dai, StereoDepthConfig, getDepthUnit))
         .def("set",                     &StereoDepthConfig::set, py::arg("config"), DOC(dai, StereoDepthConfig, set))
         .def("get",                     &StereoDepthConfig::get, DOC(dai, StereoDepthConfig, get))
         ;


### PR DESCRIPTION
Example of usage:

```
stereo.initialConfig.setDepthUnit(dai.StereoDepthConfig.AlgorithmControl.DepthUnit.CENTIMETRE)
```

Available units:
`METRE, CENTIMETRE, MILLIMETRE, INCH, FOOT, CUSTOM`

Related PR: https://github.com/luxonis/depthai-core/pull/430