### PR TITLE
Enable RGB alignment for spatial detection examples

### DIFF
--- a/examples/ObjectTracker/spatial_object_tracker.py
+++ b/examples/ObjectTracker/spatial_object_tracker.py
@@ -49,6 +49,8 @@ monoRight.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 
 # setting node configs
 stereo.setDefaultProfilePreset(dai.node.StereoDepth.PresetMode.HIGH_DENSITY)
+# Align depth map to the perspective of RGB camera, on which inference is done
+stereo.setDepthAlign(dai.CameraBoardSocket.RGB)
 
 spatialDetectionNetwork.setBlobPath(args.nnPath)
 spatialDetectionNetwork.setConfidenceThreshold(0.5)

--- a/examples/SpatialDetection/spatial_mobilenet.py
+++ b/examples/SpatialDetection/spatial_mobilenet.py
@@ -60,6 +60,8 @@ monoRight.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 
 # Setting node configs
 stereo.setDefaultProfilePreset(dai.node.StereoDepth.PresetMode.HIGH_DENSITY)
+# Align depth map to the perspective of RGB camera, on which inference is done
+stereo.setDepthAlign(dai.CameraBoardSocket.RGB)
 
 spatialDetectionNetwork.setBlobPath(nnBlobPath)
 spatialDetectionNetwork.setConfidenceThreshold(0.5)

--- a/examples/SpatialDetection/spatial_tiny_yolo.py
+++ b/examples/SpatialDetection/spatial_tiny_yolo.py
@@ -81,6 +81,8 @@ monoRight.setBoardSocket(dai.CameraBoardSocket.RIGHT)
 
 # setting node configs
 stereo.setDefaultProfilePreset(dai.node.StereoDepth.PresetMode.HIGH_DENSITY)
+# Align depth map to the perspective of RGB camera, on which inference is done
+stereo.setDepthAlign(dai.CameraBoardSocket.RGB)
 
 spatialDetectionNetwork.setBlobPath(nnBlobPath)
 spatialDetectionNetwork.setConfidenceThreshold(0.5)


### PR DESCRIPTION
Related:
https://github.com/luxonis/depthai-core/pull/457