### PR TITLE
macOS ARM64 wheels for M1 (and other) machines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,9 @@ jobs:
           path: ~/.hunter
           key: hunter-macos-latest
       - name: List .hunter cache directory
-        run: ls -a -l ~/.hunter/_Base/ || true
+        run: |
+          ls -a -l ~/.hunter/_Base/ || true
+          echo "PATH=$PATH"
 
       - uses: actions/checkout@v2
         with:
@@ -270,6 +272,63 @@ jobs:
         run: python -m pip wheel . -w ./wheelhouse/ --verbose
       - name: Auditing wheels
         run: ci/repair-whl-macos.sh `pwd`/wheelhouse/* `pwd`/wheelhouse/audited
+      - name: Archive wheel artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: audited-wheels
+          path: wheelhouse/audited/
+      - name: Deploy wheels to artifactory (if not a release)
+        if: startsWith(github.ref, 'refs/tags/v') != true
+        run: bash ./ci/upload-artifactory.sh
+        env:
+          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_PASS: ${{ secrets.ARTIFACTORY_PASS }}
+
+  # This job builds wheels for macOS arm64 arch
+  build-macos-arm64:
+    needs: build-docstrings
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      # Cached locally on runner
+      # - name: Cache .hunter folder
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ~/.hunter
+      #     key: hunter-macos-latest
+      - name: List .hunter cache directory
+        run: |
+          ls -a -l ~/.hunter/_Base/ || true
+          echo "PATH=$PATH"
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: 'docstrings'
+          path: docstrings
+      - name: Specify docstring to use while building the wheel
+        run: echo "DEPTHAI_PYTHON_DOCSTRINGS_INPUT=$PWD/docstrings/depthai_python_docstring.hpp" >> $GITHUB_ENV
+
+      - name: Append build hash if not a tagged commit
+        if: startsWith(github.ref, 'refs/tags/v') != true
+        run: echo "BUILD_COMMIT_HASH=${{github.sha}}" >> $GITHUB_ENV
+
+      # - name: Build and install depthai-core
+      #   run: |
+      #     echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
+      #     cmake -S depthai-core/ -B build_core -D CMAKE_BUILD_TYPE=Release -D CMAKE_TOOLCHAIN_FILE=$PWD/cmake/toolchain/pic.cmake
+      #     cmake --build build_core --target install --parallel 4
+      #     echo "DEPTHAI_INSTALLATION_DIR=$PWD/build_core/install/" >> $GITHUB_ENV
+
+      - name: Build wheels
+        run: for PYBIN in {9..10}; do "python3.${PYBIN}" -m pip wheel . -w wheelhouse/ --verbose; done
+
+      - name: Auditing wheels
+        run: delocate-wheel -v -w wheelhouse/audited wheelhouse/*.whl
+
       - name: Archive wheel artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -406,7 +465,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [pytest, build-linux-armhf, build-windows-x86_64, build-macos-x86_64, build-linux-x86_64, build-linux-arm64]
+    needs: [pytest, build-linux-armhf, build-windows-x86_64, build-macos-x86_64, build-macos-arm64, build-linux-x86_64, build-linux-arm64]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
     needs: build-docstrings
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Print home directory

--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -83,10 +83,6 @@ if not pip_installed:
 if sys.version_info[0] != 3:
     raise RuntimeError("Examples require Python 3 to run (detected: Python {})".format(sys.version_info[0]))
 
-if thisPlatform == "arm64" and platform.system() == "Darwin":
-    err_str = "There are no prebuilt wheels for M1 processors. Please open the following link for a solution - https://discuss.luxonis.com/d/69-running-depthai-on-apple-m1-based-macs"
-    raise RuntimeError(err_str)
-
 is_pi = thisPlatform.startswith("arm")
 prebuiltWheelsPythonVersion = [7,9]
 if requireOpenCv and is_pi and sys.version_info[1] not in prebuiltWheelsPythonVersion:


### PR DESCRIPTION
Adds explicit ARM64 wheels (compared to universal2, as the actual wheels don't contain x86_64 code along by default), and to reduce the wheel size.

On Intel Macs, pip will download the usual x86_64 wheels and on M1/M.. Macs, it'll install the ARM64