### PR TITLE
StereoDepth: Add option for disparity shift

### DIFF
--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -1245,6 +1245,7 @@ void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
         .def_readwrite("enableSubpixel", &RawStereoDepthConfig::AlgorithmControl::enableSubpixel, DOC(dai, RawStereoDepthConfig, AlgorithmControl, enableSubpixel))
         .def_readwrite("leftRightCheckThreshold", &RawStereoDepthConfig::AlgorithmControl::leftRightCheckThreshold, DOC(dai, RawStereoDepthConfig, AlgorithmControl, leftRightCheckThreshold))
         .def_readwrite("subpixelFractionalBits", &RawStereoDepthConfig::AlgorithmControl::subpixelFractionalBits, DOC(dai, RawStereoDepthConfig, AlgorithmControl, subpixelFractionalBits))
+        .def_readwrite("pixelShift", &RawStereoDepthConfig::AlgorithmControl::pixelShift, DOC(dai, RawStereoDepthConfig, AlgorithmControl, pixelShift))
         ;
 
     spatialFilter


### PR DESCRIPTION
An alternative approach to reducing the minZ is to use the “Disparity shift” parameter.  Normally the depth sensor is set to generate depth for objects at distances ranging from minZ-to-infinity. By increasing the disparity shift from 0 to 96, for example, you will be able to shift that range to a NewMinZ-to-NewMaxZ. We normally only recommend doing this when it is known that there will be no objects farther away than MaxZ, such as having a depth camera mounted above a table pointing down at the table surface. Note that, because of the inverse relationship between disparity and depth, MaxZ will decrease much faster than minZ as the disparity shift is increased. Therefore, it is advised to not use a larger than necessary disparity shift. For example, if using a disparity shift of 96 then the newMaxZ is roughly equal to the original MinZ and the newMinZ is roughly equal to half of the original MinZ. Note that the tradeoff in reducing the MinZ this way is that objects at distances farther away than MaxZ will not be seen. 

This can be combined with extended/subpixel/LR-check.

Note that the output disparity map is not expanded, only the depth map. So if disparity shift is set to 50, and disparity value obtained is 90, the real disparity is 140.

As described by Realsense:
![image](https://user-images.githubusercontent.com/60790666/177407146-d7ce3de0-3899-4fca-8f00-036637fe7530.png)
