### PR TITLE
Support for new S2/Pro devices

### DIFF
--- a/src/pipeline/NodeBindings.cpp
+++ b/src/pipeline/NodeBindings.cpp
@@ -244,6 +244,8 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         .value("THE_4_K", ColorCameraProperties::SensorResolution::THE_4_K)
         .value("THE_12_MP", ColorCameraProperties::SensorResolution::THE_12_MP)
         .value("THE_13_MP", ColorCameraProperties::SensorResolution::THE_13_MP)
+        .value("THE_720_P", ColorCameraProperties::SensorResolution::THE_720_P)
+        .value("THE_800_P", ColorCameraProperties::SensorResolution::THE_800_P)
         ;
 
     colorCameraPropertiesColorOrder


### PR DESCRIPTION
Related PR: https://github.com/luxonis/depthai-core/pull/517
> - FW: support for OAK-D-S2 / OAK-D-Pro using the latest board DM9098 R6M2E6
> - Handle new resolutions THE_720_P and THE_800_P for ColorCamera, applicable to OV9782 on RGB/center socket