### PR TITLE
Updated rgb-full-res example

### DIFF
--- a/docs/source/samples/VideoEncoder/rgb_full_resolution_saver.rst
+++ b/docs/source/samples/VideoEncoder/rgb_full_resolution_saver.rst
@@ -1,14 +1,11 @@
 RGB Full Resolution Saver
 =========================
 
-This example does its best to save full-resolution 3840x2160 .jpeg files as fast at it can from the
-RGB sensor. It serves as an example of recording high resolution to disk for the purposes of
-high-resolution ground-truth data. We also recently added the options to save isp - YUV420p
-uncompressed frames, processed by ISP, and raw - BayerRG (R_Gr_Gb_B), as read from sensor,
-10-bit packed.
+This example saves full-resolution 3840x2160 ``.jpeg`` images when ``c`` key is pressed.
+It serves as an example of recording high resolution frames to disk for the purposes of
+high-resolution ground-truth data.
 
-Be careful, this example saves pictures to your host storage. So if you leave
-it running, you could fill up your storage on your host.
+Note that each frame consumes above 2MB of storage, so "spamming" capture key could fill up your storage.
 
 .. rubric:: Similar samples:
 

--- a/examples/VideoEncoder/rgb_full_resolution_saver.py
+++ b/examples/VideoEncoder/rgb_full_resolution_saver.py
@@ -8,31 +8,35 @@ import depthai as dai
 # Create pipeline
 pipeline = dai.Pipeline()
 
-# Define sources and outputs
 camRgb = pipeline.create(dai.node.ColorCamera)
-videoEnc = pipeline.create(dai.node.VideoEncoder)
-xoutJpeg = pipeline.create(dai.node.XLinkOut)
-xoutRgb = pipeline.create(dai.node.XLinkOut)
-
-xoutJpeg.setStreamName("jpeg")
-xoutRgb.setStreamName("rgb")
-
-# Properties
 camRgb.setBoardSocket(dai.CameraBoardSocket.RGB)
 camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_4_K)
-videoEnc.setDefaultProfilePreset(camRgb.getFps(), dai.VideoEncoderProperties.Profile.MJPEG)
+
+xoutRgb = pipeline.create(dai.node.XLinkOut)
+xoutRgb.setStreamName("rgb")
+camRgb.video.link(xoutRgb.input)
+
+xin = pipeline.create(dai.node.XLinkIn)
+xin.setStreamName("control")
+xin.out.link(camRgb.inputControl)
+
+# Properties
+videoEnc = pipeline.create(dai.node.VideoEncoder)
+videoEnc.setDefaultProfilePreset(1, dai.VideoEncoderProperties.Profile.MJPEG)
+camRgb.still.link(videoEnc.input)
 
 # Linking
-camRgb.video.link(xoutRgb.input)
-camRgb.video.link(videoEnc.input)
-videoEnc.bitstream.link(xoutJpeg.input)
+xoutStill = pipeline.create(dai.node.XLinkOut)
+xoutStill.setStreamName("still")
+videoEnc.bitstream.link(xoutStill.input)
 
 # Connect to device and start pipeline
 with dai.Device(pipeline) as device:
 
     # Output queue will be used to get the rgb frames from the output defined above
     qRgb = device.getOutputQueue(name="rgb", maxSize=30, blocking=False)
-    qJpeg = device.getOutputQueue(name="jpeg", maxSize=30, blocking=True)
+    qStill = device.getOutputQueue(name="still", maxSize=30, blocking=True)
+    qControl = device.getInputQueue(name="control")
 
     # Make sure the destination path is present before starting to store the examples
     dirName = "rgb_data"
@@ -40,13 +44,21 @@ with dai.Device(pipeline) as device:
 
     while True:
         inRgb = qRgb.tryGet()  # Non-blocking call, will return a new data that has arrived or None otherwise
-
         if inRgb is not None:
-            cv2.imshow("rgb", inRgb.getCvFrame())
+            frame = inRgb.getCvFrame()
+            # 4k / 4
+            frame = cv2.pyrDown(frame)
+            frame = cv2.pyrDown(frame)
+            cv2.imshow("rgb", frame)
 
-        for encFrame in qJpeg.tryGetAll():
+        if qStill.has():
             with open(f"{dirName}/{int(time.time() * 1000)}.jpeg", "wb") as f:
-                f.write(bytearray(encFrame.getData()))
-
-        if cv2.waitKey(1) == ord('q'):
+                f.write(qStill.get().getData())
+        
+        key = cv2.waitKey(1)
+        if key == ord('q'):
             break
+        elif key == ord('c'):
+            ctrl = dai.CameraControl()
+            ctrl.setCaptureStill(True)
+            qControl.send(ctrl)


### PR DESCRIPTION
Should we update the example below to capture full 4k res mjpeg on still image, after pressing c ? I believe it would be much more relevant compared to saving every single 4k frame. TODO: update in c++ so it matches python example. CC @moratom 