### PR TITLE
Binding for node.Output.possibleDatatypes

### DIFF
--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -1,6 +1,7 @@
 #include "DatatypeBindings.hpp"
 
 #include "pipeline/CommonBindings.hpp"
+#include "depthai-shared/datatype/DatatypeEnum.hpp"
 
 void bind_adatatype(pybind11::module& m, void* pCallstack);
 void bind_apriltagconfig(pybind11::module& m, void* pCallstack);
@@ -23,6 +24,9 @@ void bind_trackedfeatures(pybind11::module& m, void* pCallstack);
 void bind_tracklets(pybind11::module& m, void* pCallstack);
 
 void DatatypeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
+     // Bind common datatypebindings
+    callstack.push_front(DatatypeBindings::bind);
+
     // Bind all datatypes (order matters)
     callstack.push_front(bind_adatatype);
     callstack.push_front(bind_buffer);
@@ -43,4 +47,47 @@ void DatatypeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
     callstack.push_front(bind_systeminformation);
     callstack.push_front(bind_trackedfeatures);
     callstack.push_front(bind_tracklets);
+}
+
+void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){
+    using namespace dai;
+
+    py::enum_<DatatypeEnum> datatypeEnum(m, "DatatypeEnum", DOC(dai, DatatypeEnum));
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+    m.def("isDatatypeSubclassOf", &isDatatypeSubclassOf);
+
+    datatypeEnum
+        .value("Buffer", DatatypeEnum::Buffer)
+        .value("ImgFrame", DatatypeEnum::ImgFrame)
+        .value("NNData", DatatypeEnum::NNData)
+        .value("ImageManipConfig", DatatypeEnum::ImageManipConfig)
+        .value("CameraControl", DatatypeEnum::CameraControl)
+        .value("ImgDetections", DatatypeEnum::ImgDetections)
+        .value("SpatialImgDetections", DatatypeEnum::SpatialImgDetections)
+        .value("SystemInformation", DatatypeEnum::SystemInformation)
+        .value("SpatialLocationCalculatorConfig", DatatypeEnum::SpatialLocationCalculatorConfig)
+        .value("SpatialLocationCalculatorData", DatatypeEnum::SpatialLocationCalculatorData)
+        .value("EdgeDetectorConfig", DatatypeEnum::EdgeDetectorConfig)
+        .value("AprilTagConfig", DatatypeEnum::AprilTagConfig)
+        .value("AprilTags", DatatypeEnum::AprilTags)
+        .value("Tracklets", DatatypeEnum::Tracklets)
+        .value("IMUData", DatatypeEnum::IMUData)
+        .value("StereoDepthConfig", DatatypeEnum::StereoDepthConfig)
+        .value("FeatureTrackerConfig", DatatypeEnum::FeatureTrackerConfig)
+        .value("TrackedFeatures", DatatypeEnum::TrackedFeatures)
+    ;
+
 }

--- a/src/DatatypeBindings.hpp
+++ b/src/DatatypeBindings.hpp
@@ -5,4 +5,6 @@
 
 struct DatatypeBindings {
     static void addToCallstack(std::deque<StackFunction>& callstack);
+ private:
+    static void bind(pybind11::module& m, void* pCallstack);
 };

--- a/src/pipeline/node/NodeBindings.cpp
+++ b/src/pipeline/node/NodeBindings.cpp
@@ -155,6 +155,7 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
     py::class_<Node::Output> pyOutput(pyNode, "Output", DOC(dai, Node, Output));
     py::enum_<Node::Output::Type> nodeOutputType(pyOutput, "Type");
     py::class_<Properties, std::shared_ptr<Properties>> pyProperties(m, "Properties", DOC(dai, Properties));
+    py::class_<Node::DatatypeHierarchy> nodeDatatypeHierarchy(pyNode, "DatatypeHierarchy", DOC(dai, Node, DatatypeHierarchy));
 
 
     // Node::Id bindings
@@ -189,6 +190,12 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
 
     // Base 'Node' class binding
 
+    nodeDatatypeHierarchy
+        .def(py::init<DatatypeEnum, bool>())
+        .def_readwrite("datatype", &Node::DatatypeHierarchy::datatype)
+        .def_readwrite("descendants", &Node::DatatypeHierarchy::descendants)
+    ;
+
     // Node::Input bindings
     nodeInputType
         .value("SReceiver", Node::Input::Type::SReceiver)
@@ -218,12 +225,12 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         .def_property("group", [](Node::Output& obj) -> std::string& { return obj.group; }, [](Node::Output& obj, std::string group) { obj.group = group; })
         .def_property("name", [](Node::Output& obj) -> std::string& { return obj.name; }, [](Node::Output& obj, std::string name) { obj.name = name; })
         .def_property("type", [](Node::Output& obj) -> Node::Output::Type& { return obj.type; }, [](Node::Output& obj, Node::Output::Type type) { obj.type = type; })
+        .def_property("possibleDatatypes", [](Node::Output& obj) -> std::vector<Node::DatatypeHierarchy>& { return obj.possibleDatatypes; }, [](Node::Output& obj, std::vector<Node::DatatypeHierarchy> possibleDatatypes) { obj.possibleDatatypes = possibleDatatypes; })
         .def("canConnect", &Node::Output::canConnect, py::arg("input"), DOC(dai, Node, Output, canConnect))
         .def("link", &Node::Output::link, py::arg("input"), DOC(dai, Node, Output, link))
         .def("unlink", &Node::Output::unlink, py::arg("input"), DOC(dai, Node, Output, unlink))
         .def("getConnections", &Node::Output::getConnections, DOC(dai, Node, Output, getConnections))
     ;
-
 
     nodeConnection
         .def_property("outputId", [](Node::Connection& conn) -> Node::Id& { return conn.outputId; }, [](Node::Connection& conn, Node::Id id) {conn.outputId = id; }, DOC(dai, Node, Connection, outputId))

--- a/src/pipeline/node/NodeBindings.cpp
+++ b/src/pipeline/node/NodeBindings.cpp
@@ -202,14 +202,14 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         .value("MReceiver", Node::Input::Type::MReceiver)
     ;
     pyInput
-        .def_property("group", [](Node::Input& obj) { return obj.group; }, [](Node::Input& obj, std::string group) { obj.group = group; })
-        .def_property("name", [](Node::Input& obj) { return obj.name; }, [](Node::Input& obj, std::string name) { obj.name = name; })
-        .def_property("type", [](Node::Input& obj) { return obj.type; }, [](Node::Input& obj, Node::Input::Type type) { obj.type = type; })
+        .def_readwrite("group", &Node::Input::group, DOC(dai, Node, Input, group))
+        .def_readwrite("name", &Node::Input::name, DOC(dai, Node, Input, name))
+        .def_readwrite("type", &Node::Input::type, DOC(dai, Node, Input, type))
         .def("setBlocking", &Node::Input::setBlocking, py::arg("blocking"), DOC(dai, Node, Input, setBlocking))
         .def("getBlocking", &Node::Input::getBlocking, DOC(dai, Node, Input, getBlocking))
         .def("setQueueSize", &Node::Input::setQueueSize, py::arg("size"), DOC(dai, Node, Input, setQueueSize))
         .def("getQueueSize", &Node::Input::getQueueSize, DOC(dai, Node, Input, getQueueSize))
-        .def_property("waitForMessage", [](Node::Input& obj) { return obj.type; }, [](Node::Input& obj, bool waitForMessage) { obj.waitForMessage = waitForMessage; })
+        .def_readwrite("waitForMessage", &Node::Input::waitForMessage, DOC(dai, Node, Input, waitForMessage))
         .def("setWaitForMessage", &Node::Input::setWaitForMessage, py::arg("waitForMessage"), DOC(dai, Node, Input, setWaitForMessage))
         .def("getWaitForMessage", &Node::Input::getWaitForMessage, DOC(dai, Node, Input, getWaitForMessage))
         .def("setReusePreviousMessage", &Node::Input::setReusePreviousMessage, py::arg("reusePreviousMessage"), DOC(dai, Node, Input, setReusePreviousMessage))
@@ -222,10 +222,10 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         .value("SSender", Node::Output::Type::SSender)
     ;
     pyOutput
-        .def_property("group", [](Node::Output& obj) -> std::string& { return obj.group; }, [](Node::Output& obj, std::string group) { obj.group = group; })
-        .def_property("name", [](Node::Output& obj) -> std::string& { return obj.name; }, [](Node::Output& obj, std::string name) { obj.name = name; })
-        .def_property("type", [](Node::Output& obj) -> Node::Output::Type& { return obj.type; }, [](Node::Output& obj, Node::Output::Type type) { obj.type = type; })
-        .def_property("possibleDatatypes", [](Node::Output& obj) -> std::vector<Node::DatatypeHierarchy>& { return obj.possibleDatatypes; }, [](Node::Output& obj, std::vector<Node::DatatypeHierarchy> possibleDatatypes) { obj.possibleDatatypes = possibleDatatypes; })
+        .def_readwrite("group", &Node::Output::group, DOC(dai, Node, Output, group))
+        .def_readwrite("name", &Node::Output::name, DOC(dai, Node, Output, name))
+        .def_readwrite("type", &Node::Output::type, DOC(dai, Node, Output, type))
+        .def_readwrite("possibleDatatypes", &Node::Output::possibleDatatypes, DOC(dai, Node, Output, possibleDatatypes))
         .def("canConnect", &Node::Output::canConnect, py::arg("input"), DOC(dai, Node, Output, canConnect))
         .def("link", &Node::Output::link, py::arg("input"), DOC(dai, Node, Output, link))
         .def("unlink", &Node::Output::unlink, py::arg("input"), DOC(dai, Node, Output, unlink))
@@ -233,12 +233,12 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
     ;
 
     nodeConnection
-        .def_property("outputId", [](Node::Connection& conn) -> Node::Id& { return conn.outputId; }, [](Node::Connection& conn, Node::Id id) {conn.outputId = id; }, DOC(dai, Node, Connection, outputId))
-        .def_property("outputName", [](Node::Connection& conn) -> std::string& { return conn.outputName; }, [](Node::Connection& conn, std::string name) {conn.outputName = name; }, DOC(dai, Node, Connection, outputName))
-        .def_property("outputGroup", [](Node::Connection& conn) -> std::string& { return conn.outputGroup; }, [](Node::Connection& conn, std::string group) {conn.outputGroup = group; }, DOC(dai, Node, Connection, outputGroup))
-        .def_property("inputId", [](Node::Connection& conn) -> Node::Id& { return conn.inputId; }, [](Node::Connection& conn, Node::Id id) {conn.inputId = id; }, DOC(dai, Node, Connection, inputId))
-        .def_property("inputName", [](Node::Connection& conn) -> std::string& { return conn.inputName; }, [](Node::Connection& conn, std::string name) {conn.inputName = name; }, DOC(dai, Node, Connection, inputName))
-        .def_property("inputGroup", [](Node::Connection& conn) -> std::string& { return conn.inputGroup; }, [](Node::Connection& conn, std::string group) {conn.inputGroup = group; }, DOC(dai, Node, Connection, inputGroup))
+        .def_readwrite("outputId", &Node::Connection::outputId, DOC(dai, Node, Connection, outputId))
+        .def_readwrite("outputName", &Node::Connection::outputName, DOC(dai, Node, Connection, outputName))
+        .def_readwrite("outputGroup", &Node::Connection::outputGroup, DOC(dai, Node, Connection, outputGroup))
+        .def_readwrite("inputId", &Node::Connection::inputId, DOC(dai, Node, Connection, inputId))
+        .def_readwrite("inputName", &Node::Connection::inputName, DOC(dai, Node, Connection, inputName))
+        .def_readwrite("inputGroup", &Node::Connection::inputGroup, DOC(dai, Node, Connection, inputGroup))
     ;
 
     pyNode
@@ -256,16 +256,6 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack){
         .def("getAssetManager", static_cast<AssetManager& (Node::*)()>(&Node::getAssetManager), py::return_value_policy::reference_internal, DOC(dai, Node, getAssetManager))
         .def_property("properties", [](Node& n) -> const Properties& { return n.properties; }, [](Node& n, const Properties& p) { n.properties = p; }, DOC(dai, Node, properties), py::return_value_policy::reference_internal)
     ;
-
-    // MSVC errors out with:
-    // Error C2326 'void NodeBindings::bind(pybind11::module &)': function cannot access 'dai::Node::Connection::outputId'
-    // ...
-    // py::class_<Node::Connection>(pyNode, "Connection")
-    //     .def_readwrite("outputId", &dai::Node::Connection::outputId)
-    //     .def_readwrite("outputName", &dai::Node::Connection::outputName)
-    //     .def_readwrite("inputId", &dai::Node::Connection::inputId)
-    //     .def_readwrite("inputName", &dai::Node::Connection::inputName)
-    // ;
 
 }
 

--- a/src/pipeline/node/NodeBindings.hpp
+++ b/src/pipeline/node/NodeBindings.hpp
@@ -6,7 +6,7 @@
 // depthai
 #include "depthai/pipeline/Node.hpp"
 
-struct NodeBindings : public dai::Node {
+struct NodeBindings {
     static void addToCallstack(std::deque<StackFunction>& callstack);
     static std::vector<std::pair<py::handle, std::function<std::shared_ptr<dai::Node>(dai::Pipeline&, py::object class_)>>> getNodeCreateMap();
  private:

--- a/src/pipeline/node/SpatialDetectionNetworkBindings.cpp
+++ b/src/pipeline/node/SpatialDetectionNetworkBindings.cpp
@@ -54,8 +54,8 @@ void bind_spatialdetectionnetwork(pybind11::module& m, void* pCallstack){
      // ALIAS
     daiNodeModule.attr("SpatialDetectionNetwork").attr("Properties") = spatialDetectionNetworkProperties;
 
-    // MobileNetSpatialDetectionNetwork
-    mobileNetSpatialDetectionNetwork;
+    // // MobileNetSpatialDetectionNetwork
+    // mobileNetSpatialDetectionNetwork;
     // YoloSpatialDetectionNetwork
     yoloSpatialDetectionNetwork
         .def("setNumClasses", &YoloSpatialDetectionNetwork::setNumClasses, py::arg("numClasses"), DOC(dai, node, YoloSpatialDetectionNetwork, setNumClasses))


### PR DESCRIPTION
Doesn't work (so more of a feature request), @themarpe  please add bindings for this:)

```
depthai-python/src/pipeline/node/NodeBindings.cpp:221:107: error: invalid initialization of reference of type ‘dai::Node::DatatypeHierarchy&’ from expression of type ‘std::vector<dai::Node::DatatypeHierarchy>
```