### PR TITLE
update usage code sample in python

### DIFF
--- a/docs/source/components/nodes/video_encoder.rst
+++ b/docs/source/components/nodes/video_encoder.rst
@@ -51,7 +51,7 @@ Usage
     # Create ColorCamera beforehand
     # Set H265 encoding for the ColorCamera video output
     videoEncoder = pipeline.create(dai.node.VideoEncoder)
-    videoEncoder.setDefaultProfilePreset(cam.getVideoSize(), cam.getFps(), dai.VideoEncoderProperties.Profile.H265_MAIN)
+    videoEncoder.setDefaultProfilePreset(cam.getFps(), dai.VideoEncoderProperties.Profile.H265_MAIN)
 
     # Create MJPEG encoding for still images
     stillEncoder = pipeline.create(dai.node.VideoEncoder)


### PR DESCRIPTION
passing cam.getVideoSize() to videoEncoder.setDefaultProfilePreset generates DeprecationWarning: Input size no longer needed, automatically determined from first frame