### PR TITLE
Fixed a bug in rotated_spatial_detections.py

### DIFF
--- a/examples/mixed/rotated_spatial_detections.py
+++ b/examples/mixed/rotated_spatial_detections.py
@@ -87,7 +87,7 @@ spatialDetectionNetwork.out.link(xoutNN.input)
 
 rotate_stereo_manip.out.link(spatialDetectionNetwork.inputDepth)
 spatialDetectionNetwork.passthroughDepth.link(xoutDepth.input)
-
+color = (255, 0, 0)
 # Connect to device and start pipeline
 with dai.Device(pipeline) as device:
 


### PR DESCRIPTION
`color` wasn't defined and the example crashed if it detected anything