### PR TITLE
ubuntu pre 22 and 22 fixed

### DIFF
--- a/docs/source/_static/install_dependencies.sh
+++ b/docs/source/_static/install_dependencies.sh
@@ -47,12 +47,12 @@ readonly ubuntu_pkgs=(
 
 readonly ubuntu_pkgs_pre22_04=(
     "${ubuntu_pkgs[@]}"
-    libdc1394-dev
+    libdc1394-22-dev
 )
 
 readonly ubuntu_pkgs_22_04=(
     "${ubuntu_pkgs[@]}"
-    libdc1394-22-dev
+    libdc1394-dev
 )
 
 readonly ubuntu_arm_pkgs=(


### PR DESCRIPTION
libdc1394-22-dev works before ubuntu 22 and libdc1394-dev works for ubuntu 22