### PR TITLE
Updated supported platforms and test requirements installation

### DIFF
--- a/.github/workflows/test-install-dependencies.yml
+++ b/.github/workflows/test-install-dependencies.yml
@@ -7,6 +7,9 @@
       - 'docs/source/_static/install_dependencies.sh'
       - 'examples/install_requirements.py'
   pull_request:
+      paths:
+      - 'docs/source/_static/install_dependencies.sh'
+      - 'examples/install_requirements.py'
 
  jobs:
    install_dependencies:

--- a/.github/workflows/test-install-dependencies.yml
+++ b/.github/workflows/test-install-dependencies.yml
@@ -1,0 +1,33 @@
+ name: Test dependencies and requirements installation
+
+ on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'docs/source/_static/install_dependencies.sh'
+      - 'examples/install_requirements.py'
+
+ jobs:
+   install_dependencies:
+     runs-on: ubuntu-latest
+     strategy:
+       matrix:
+          container_image: ["fedora:34", "fedora:35", "fedora:36", "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04"]
+     container:
+       image: ${{ matrix.container_image }}
+     steps:
+       - uses: actions/checkout@v3
+       - name: Install sudo
+         if: startsWith(matrix.container_image, 'fedora') == true
+         run: yum update -y && yum install -y sudo
+       - name: Install sudo
+         if: startsWith(matrix.container_image, 'ubuntu') == true
+         run: apt-get update  -qq && apt-get -qq install sudo
+       - name: Install dependencies
+         run: |
+           ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone # Otherwise tzdata installer prompts for user input
+           sed '/udevadm control --reload-rules && sudo udevadm trigger/d' docs/source/_static/install_dependencies.sh > tmp_script.sh # Doesn't work on docker
+           bash tmp_script.sh
+       - name: Install example requirements
+         run: |
+           python3 examples/install_requirements.py

--- a/.github/workflows/test-install-dependencies.yml
+++ b/.github/workflows/test-install-dependencies.yml
@@ -6,6 +6,7 @@
     paths:
       - 'docs/source/_static/install_dependencies.sh'
       - 'examples/install_requirements.py'
+  pull_request:
 
  jobs:
    install_dependencies:

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ If `TEST_TIMEOUT=0`, the test will run until stopped or it ends.
 
 ## Tested platforms
 
-- Windows 10
-- Ubuntu 16.04, 18.04;
+- Windows 10, Windows 11
+- Ubuntu 18.04, 20.04, 22.04;
 - Raspbian 10;
 - macOS 10.14.6, 10.15.4;
 

--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -5,8 +5,6 @@ import argparse
 import re
 import platform
 
-# TODO remove, just for testing
-
 convert_default = "empty"
 parser = argparse.ArgumentParser()
 parser.add_argument('-sdai', "--skip_depthai", action="store_true", help="Skip installation of depthai library.")

--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -5,6 +5,8 @@ import argparse
 import re
 import platform
 
+# TODO remove, just for testing
+
 convert_default = "empty"
 parser = argparse.ArgumentParser()
 parser.add_argument('-sdai', "--skip_depthai", action="store_true", help="Skip installation of depthai library.")


### PR DESCRIPTION
Added jobs that test, if `examples/install_requirements.py` works on:

- Ubuntu 18.04 20.04 22.04
- Fedora 34 35 36

Ubuntu 16.04 doesn't work out of the box, as you can't easily install a python version that is newer than `python3.5`.
I propose we drop the 16.04 from the official support - alternately I will add a way to install python3.6 and add the 16.04 to the CI. 