### PR TITLE
Fix 'bash: line 231: cho: command not found'

### DIFF
--- a/docs/source/_static/install_depthai.sh
+++ b/docs/source/_static/install_depthai.sh
@@ -227,8 +227,8 @@ else
   exit 99
 fi
 
-echo $'\n\n:::::::::::::::: INSTALATION COMPLETE ::::::::::::::::\n'
-echo $'\nTo run demo app write <depthai_launcher> in terminal.'
+echo '\n\n:::::::::::::::: INSTALATION COMPLETE ::::::::::::::::\n'
+echo '\nTo run demo app write <depthai_launcher> in terminal.'
 read -rsp $'Press ANY KEY to finish and run the demo app...\n' -n1 key
 echo "STARTING DEMO APP."
 python "$DEPTHAI_DIR/launcher/launcher.py" -r "$DEPTHAI_DIR"


### PR DESCRIPTION
On bash based shells the install_depthai.sh script fails to execute due to superfluous dollar signs in the echo statements.