### PR TITLE
Release 2.20.1.0

### DIFF
--- a/examples/Camera/camera_preview.py
+++ b/examples/Camera/camera_preview.py
@@ -5,7 +5,7 @@ import depthai as dai
 import time
 
 # Connect to device and start pipeline
-with dai.Device(dai.OpenVINO.DEFAULT_VERSION, dai.UsbSpeed.SUPER_PLUS) as device:
+with dai.Device() as device:
     # Device name
     print('Device name:', device.getDeviceName())
     # Bootloader version

--- a/examples/calibration/calibration_flash.py
+++ b/examples/calibration/calibration_flash.py
@@ -12,7 +12,7 @@ parser.add_argument('calibJsonFile', nargs='?', help="Path to calibration file i
 args = parser.parse_args()
 
 # Connect device
-with dai.Device(dai.UsbSpeed.HIGH) as device:
+with dai.Device(dai.OpenVINO.VERSION_UNIVERSAL, dai.UsbSpeed.HIGH) as device:
 
     deviceCalib = device.readCalibration()
     deviceCalib.eepromToJsonFile(calibBackUpFile)

--- a/examples/calibration/calibration_flash.py
+++ b/examples/calibration/calibration_flash.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-import cv2
 import depthai as dai
 import argparse
 
@@ -13,7 +12,7 @@ parser.add_argument('calibJsonFile', nargs='?', help="Path to calibration file i
 args = parser.parse_args()
 
 # Connect device
-with dai.Device(dai.OpenVINO.VERSION_2021_4, dai.UsbSpeed.HIGH) as device:
+with dai.Device(dai.UsbSpeed.HIGH) as device:
 
     deviceCalib = device.readCalibration()
     deviceCalib.eepromToJsonFile(calibBackUpFile)

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -250,7 +250,7 @@ static void bindConstructors(ARG& arg){
         auto dev = deviceSearchHelper<D>();
         py::gil_scoped_release release;
         return std::make_unique<D>(version, dev);
-    }), py::arg("version") = OpenVINO::DEFAULT_VERSION, DOC(dai, DeviceBase, DeviceBase, 10))
+    }), py::arg("version") = OpenVINO::VERSION_UNIVERSAL, DOC(dai, DeviceBase, DeviceBase, 10))
     .def(py::init([](OpenVINO::Version version, bool usb2Mode){
         auto dev = deviceSearchHelper<D>();
         py::gil_scoped_release release;
@@ -491,7 +491,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
         .def_static("getAnyAvailableDevice", [](){ return DeviceBase::getAnyAvailableDevice(); }, DOC(dai, DeviceBase, getAnyAvailableDevice, 2))
         .def_static("getFirstAvailableDevice", &DeviceBase::getFirstAvailableDevice, py::arg("skipInvalidDevices") = true, DOC(dai, DeviceBase, getFirstAvailableDevice))
         .def_static("getAllAvailableDevices", &DeviceBase::getAllAvailableDevices, DOC(dai, DeviceBase, getAllAvailableDevices))
-        .def_static("getEmbeddedDeviceBinary", py::overload_cast<bool, OpenVINO::Version>(&DeviceBase::getEmbeddedDeviceBinary), py::arg("usb2Mode"), py::arg("version") = OpenVINO::DEFAULT_VERSION, DOC(dai, DeviceBase, getEmbeddedDeviceBinary))
+        .def_static("getEmbeddedDeviceBinary", py::overload_cast<bool, OpenVINO::Version>(&DeviceBase::getEmbeddedDeviceBinary), py::arg("usb2Mode"), py::arg("version") = OpenVINO::VERSION_UNIVERSAL, DOC(dai, DeviceBase, getEmbeddedDeviceBinary))
         .def_static("getEmbeddedDeviceBinary", py::overload_cast<DeviceBase::Config>(&DeviceBase::getEmbeddedDeviceBinary), py::arg("config"), DOC(dai, DeviceBase, getEmbeddedDeviceBinary, 2))
         .def_static("getDeviceByMxId", &DeviceBase::getDeviceByMxId, py::arg("mxId"), DOC(dai, DeviceBase, getDeviceByMxId))
         .def_static("getAllConnectedDevices", &DeviceBase::getAllConnectedDevices, DOC(dai, DeviceBase, getAllConnectedDevices))

--- a/src/openvino/OpenVINOBindings.cpp
+++ b/src/openvino/OpenVINOBindings.cpp
@@ -52,6 +52,7 @@ void OpenVINOBindings::bind(pybind11::module& m, void* pCallstack){
         .value("VERSION_2021_3", OpenVINO::Version::VERSION_2021_3)
         .value("VERSION_2021_4", OpenVINO::Version::VERSION_2021_4)
         .value("VERSION_2022_1", OpenVINO::Version::VERSION_2022_1)
+        .value("VERSION_UNIVERSAL", OpenVINO::Version::VERSION_UNIVERSAL)
         .export_values()
     ;
     // DEFAULT_VERSION binding

--- a/src/pipeline/PipelineBindings.cpp
+++ b/src/pipeline/PipelineBindings.cpp
@@ -94,7 +94,7 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack){
         .def("unlink", &Pipeline::unlink, DOC(dai, Pipeline, unlink), DOC(dai, Pipeline, unlink))
         .def("getAssetManager", static_cast<const AssetManager& (Pipeline::*)() const>(&Pipeline::getAssetManager), py::return_value_policy::reference_internal, DOC(dai, Pipeline, getAssetManager))
         .def("getAssetManager", static_cast<AssetManager& (Pipeline::*)()>(&Pipeline::getAssetManager), py::return_value_policy::reference_internal, DOC(dai, Pipeline, getAssetManager))
-        .def("setOpenVINOVersion", &Pipeline::setOpenVINOVersion, py::arg("version") = OpenVINO::DEFAULT_VERSION, DOC(dai, Pipeline, setOpenVINOVersion))
+        .def("setOpenVINOVersion", &Pipeline::setOpenVINOVersion, py::arg("version"), DOC(dai, Pipeline, setOpenVINOVersion))
         .def("getOpenVINOVersion", &Pipeline::getOpenVINOVersion, DOC(dai, Pipeline, getOpenVINOVersion))
         .def("getRequiredOpenVINOVersion", &Pipeline::getRequiredOpenVINOVersion, DOC(dai, Pipeline, getRequiredOpenVINOVersion))
         .def("setCameraTuningBlobPath", &Pipeline::setCameraTuningBlobPath, py::arg("path"), DOC(dai, Pipeline, setCameraTuningBlobPath))


### PR DESCRIPTION
# Version 2.20.1 
crucial hotfix release

## Bug fixes
 - Modified OpenVINO::VERSION_UNIVERSAL API improvements / backward compatibility
 - Bootloader version 0.0.24 (fixes for standalone / flashed usecases)
 - Missing bindings

## Misc
 - [FW] Status LEDs on some additional devices


# Version 2.20.0

## New
 - Experimental `Camera` node - supports both Color and Mono sensors, undistort from calibration or user provided warp mesh
 - OpenVINO Version `universal` - no need to downselect OpenVINO before connecting to a device
 - **OAK-D LR support**
 - Added Status LED on supported boards

## Features
 - **ImageManip** - Colormap capabilities (see `depth_colormap` example)
 - **Bootloader** update to v0.0.23 - `NETWORK` type supports dual protocol (both USB & ETH)
 - **OV9282** - bumped max **FPS to 120**
 - FrameEvent capabilities
 - **Added pipeline debugging capabilities** (see `depthai_pipeline_viewer` repository)
 - **IMX296** support
 - #668 
 - #645 

## Bug fixes
 - Eeprom exception handling
 - **ImageManip + Subpixel crash fix**

## Misc
 - XLINK_LEVEL env var to set XLink logging level
 - Device - Added non exclusive boot option
 - Removed OpenVINO `VERSION_2020_3`
 - Convinience Device constructors (`dai::Device device('ip')`, ...)
 - Soft watchdog to gracefully shutdown the device
 - Camera naming

 