### PR TITLE
RVC3 multi stereo support

### DIFF
--- a/src/CalibrationHandlerBindings.cpp
+++ b/src/CalibrationHandlerBindings.cpp
@@ -46,6 +46,7 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack){
         .def("getCameraExtrinsics", &CalibrationHandler::getCameraExtrinsics, py::arg("srcCamera"), py::arg("dstCamera"), py::arg("useSpecTranslation") = false, DOC(dai, CalibrationHandler, getCameraExtrinsics))
 
         .def("getCameraTranslationVector", &CalibrationHandler::getCameraTranslationVector, py::arg("srcCamera"), py::arg("dstCamera"), py::arg("useSpecTranslation") = true, DOC(dai, CalibrationHandler, getCameraTranslationVector))
+        .def("getCameraRotationMatrix", &CalibrationHandler::getCameraRotationMatrix, py::arg("srcCamera"), py::arg("dstCamera"), DOC(dai, CalibrationHandler, getCameraRotationMatrix))
         .def("getBaselineDistance", &CalibrationHandler::getBaselineDistance, py::arg("cam1") = dai::CameraBoardSocket::RIGHT, py::arg("cam2") = dai::CameraBoardSocket::LEFT, py::arg("useSpecTranslation") = true, DOC(dai, CalibrationHandler, getBaselineDistance))
 
         .def("getCameraToImuExtrinsics", &CalibrationHandler::getCameraToImuExtrinsics, py::arg("cameraId"), py::arg("useSpecTranslation") = false, DOC(dai, CalibrationHandler, getCameraToImuExtrinsics))


### PR DESCRIPTION
Support for stereo between any 2 cameras (including vertical).
Removed verttical stereo rectification matrix API

https://github.com/luxonis/depthai-core/pull/715