### PR TITLE
Crash dump support for debugging

### DIFF
--- a/examples/CrashReport/crash_report.py
+++ b/examples/CrashReport/crash_report.py
@@ -3,19 +3,32 @@
 import cv2
 import depthai as dai
 from json import dump
+from os.path import exists
 
 # Connect to device and start pipeline
 with dai.Device() as device:
 
     if device.hasCrashDump():
         crashDump = device.getCrashDump()
+        commitHash = crashDump.depthaiCommitHash
+        deviceId = crashDump.deviceId
 
         json = crashDump.serializeToJson()
-        print(json)
         
-        destPath = "crashDump.json"
-        with open(destPath, 'w', encoding='utf-8') as f:
-            dump(json, f, ensure_ascii=False, indent=4)
+        i = -1
+        while True:
+            i += 1
+            destPath = "crashDump_" + str(i) + "_" + deviceId + "_" + commitHash + ".json"
+            if exists(destPath):
+                continue
+
+            with open(destPath, 'w', encoding='utf-8') as f:
+                dump(json, f, ensure_ascii=False, indent=4)
+
+            print("Crash dump found on your device!")
+            print(f"Saved to {destPath}")
+            print("Please report to developers!")
+            break
     else:
         print("There was no crash dump found on your device!")
 

--- a/examples/CrashReport/crash_report.py
+++ b/examples/CrashReport/crash_report.py
@@ -2,7 +2,7 @@
 
 import cv2
 import depthai as dai
-import json
+from json import dump
 
 # Connect to device and start pipeline
 with dai.Device() as device:
@@ -15,4 +15,4 @@ with dai.Device() as device:
         print(json)
         destPath = "crashDump.json"
         with open(destPath, 'w', encoding='utf-8') as f:
-            json.dump(data, f, ensure_ascii=False, indent=4)
+            dump(json, f, ensure_ascii=False, indent=4)

--- a/examples/CrashReport/crash_report.py
+++ b/examples/CrashReport/crash_report.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import cv2
+import depthai as dai
+import json
+
+# Connect to device and start pipeline
+with dai.Device() as device:
+
+    crashDump = device.getCrashDump()
+    if len(crashDump.crashReports) == 0:
+        print("There was no crash dump found on your device!")
+    else:
+        json = crashDump.serializeToJson()
+        print(json)
+        destPath = "crashDump.json"
+        with open(destPath, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)

--- a/examples/CrashReport/crash_report.py
+++ b/examples/CrashReport/crash_report.py
@@ -7,12 +7,15 @@ from json import dump
 # Connect to device and start pipeline
 with dai.Device() as device:
 
-    crashDump = device.getCrashDump()
-    if len(crashDump.crashReports) == 0:
-        print("There was no crash dump found on your device!")
-    else:
+    if device.hasCrashDump():
+        crashDump = device.getCrashDump()
+
         json = crashDump.serializeToJson()
         print(json)
+        
         destPath = "crashDump.json"
         with open(destPath, 'w', encoding='utf-8') as f:
             dump(json, f, ensure_ascii=False, indent=4)
+    else:
+        print("There was no crash dump found on your device!")
+

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -495,6 +495,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
         .def(py::init<>())
         .def_readwrite("processor", &CrashDump::CrashReport::processor, DOC(dai, CrashDump, CrashReport, processor))
         .def_readwrite("errorSource", &CrashDump::CrashReport::errorSource, DOC(dai, CrashDump, CrashReport, errorSource))
+        .def_readwrite("crashedThreadId", &CrashDump::CrashReport::crashedThreadId, DOC(dai, CrashDump, CrashReport, crashedThreadId))
         .def_readwrite("threadCallstack", &CrashDump::CrashReport::threadCallstack, DOC(dai, CrashDump, CrashReport, threadCallstack))
     ;
  

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -485,6 +485,8 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
     // Bind CrashDump
     crashDump
         .def(py::init<>())
+        .def("serializeToJson", &CrashDump::serializeToJson, DOC(dai, CrashDump, serializeToJson))
+        
         .def_readwrite("crashReports", &CrashDump::crashReports, DOC(dai, CrashDump, crashReports))
         .def_readwrite("depthaiCommitHash", &CrashDump::depthaiCommitHash, DOC(dai, CrashDump, depthaiCommitHash))
     ;

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -489,6 +489,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
         
         .def_readwrite("crashReports", &CrashDump::crashReports, DOC(dai, CrashDump, crashReports))
         .def_readwrite("depthaiCommitHash", &CrashDump::depthaiCommitHash, DOC(dai, CrashDump, depthaiCommitHash))
+        .def_readwrite("deviceId", &CrashDump::deviceId, DOC(dai, CrashDump, deviceId))
     ;
 
     crashReport

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -587,6 +587,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
         .def("setSystemInformationLoggingRate", [](DeviceBase& d, float hz) { py::gil_scoped_release release; d.setSystemInformationLoggingRate(hz); }, py::arg("rateHz"), DOC(dai, DeviceBase, setSystemInformationLoggingRate))
         .def("getSystemInformationLoggingRate", [](DeviceBase& d) { py::gil_scoped_release release; return d.getSystemInformationLoggingRate(); }, DOC(dai, DeviceBase, getSystemInformationLoggingRate))
         .def("getCrashDump", [](DeviceBase& d) { py::gil_scoped_release release; return d.getCrashDump(); }, DOC(dai, DeviceBase, getCrashDump))
+        .def("hasCrashDump", [](DeviceBase& d) { py::gil_scoped_release release; return d.hasCrashDump(); }, DOC(dai, DeviceBase, hasCrashDump))
         .def("getConnectedCameras", [](DeviceBase& d) { py::gil_scoped_release release; return d.getConnectedCameras(); }, DOC(dai, DeviceBase, getConnectedCameras))
         .def("getConnectedCameraFeatures", [](DeviceBase& d) { py::gil_scoped_release release; return d.getConnectedCameraFeatures(); }, DOC(dai, DeviceBase, getConnectedCameraFeatures))
         .def("getCameraSensorNames", [](DeviceBase& d) { py::gil_scoped_release release; return d.getCameraSensorNames(); }, DOC(dai, DeviceBase, getCameraSensorNames))

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -6,6 +6,7 @@
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/utility/Clock.hpp"
 #include "depthai/xlink/XLinkConnection.hpp"
+#include "depthai-shared/device/CrashDump.hpp"
 
 // std::chrono bindings
 #include <pybind11/chrono.h>
@@ -321,6 +322,13 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
     py::class_<DeviceBase> deviceBase(m, "DeviceBase", DOC(dai, DeviceBase));
     py::class_<Device, DeviceBase> device(m, "Device", DOC(dai, Device));
     py::class_<Device::Config> deviceConfig(device, "Config", DOC(dai, DeviceBase, Config));
+    py::class_<CrashDump> crashDump(m, "CrashDump", DOC(dai, CrashDump));
+    py::class_<CrashDump::CrashReport> crashReport(crashDump, "CrashReport", DOC(dai, CrashDump, CrashReport));
+    py::class_<CrashDump::CrashReport::ErrorSourceInfo> errorSourceInfo(crashReport, "ErrorSourceInfo", DOC(dai, CrashDump, CrashReport, ErrorSourceInfo));
+    py::class_<CrashDump::CrashReport::ErrorSourceInfo::AssertContext> assertContext(errorSourceInfo, "AssertContext", DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, AssertContext));
+    py::class_<CrashDump::CrashReport::ErrorSourceInfo::TrapContext> trapContext(errorSourceInfo, "TrapContext", DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, TrapContext));
+    py::class_<CrashDump::CrashReport::ThreadCallstack> threadCallstack(crashReport, "ThreadCallstack", DOC(dai, CrashDump, CrashReport, ThreadCallstack));
+    py::class_<CrashDump::CrashReport::ThreadCallstack::CallstackContext> callstackContext(threadCallstack, "CallstackContext", DOC(dai, CrashDump, CrashReport, ThreadCallstack, CallstackContext));
     py::class_<BoardConfig> boardConfig(m, "BoardConfig", DOC(dai, BoardConfig));
     py::class_<BoardConfig::USB> boardConfigUsb(boardConfig, "USB", DOC(dai, BoardConfig, USB));
     py::class_<BoardConfig::Network> boardConfigNetwork(boardConfig, "Network", DOC(dai, BoardConfig, Network));
@@ -474,6 +482,60 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
         .def_readwrite("nonExclusiveMode", &Device::Config::nonExclusiveMode)
     ;
 
+    // Bind CrashDump
+    crashDump
+        .def(py::init<>())
+        .def_readwrite("crashReports", &CrashDump::crashReports, DOC(dai, CrashDump, crashReports))
+    ;
+
+    crashReport
+        .def(py::init<>())
+        .def_readwrite("processor", &CrashDump::CrashReport::processor, DOC(dai, CrashDump, CrashReport, processor))
+        .def_readwrite("errorSource", &CrashDump::CrashReport::errorSource, DOC(dai, CrashDump, CrashReport, errorSource))
+        .def_readwrite("threadCallstack", &CrashDump::CrashReport::threadCallstack, DOC(dai, CrashDump, CrashReport, threadCallstack))
+    ;
+ 
+    errorSourceInfo
+        .def(py::init<>())
+        .def_readwrite("assertContext", &CrashDump::CrashReport::ErrorSourceInfo::assertContext, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, assertContext))
+        .def_readwrite("trapContext", &CrashDump::CrashReport::ErrorSourceInfo::trapContext, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, trapContext))
+        .def_readwrite("errorId", &CrashDump::CrashReport::ErrorSourceInfo::errorId, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, errorId))
+    ;
+
+    assertContext
+        .def(py::init<>())
+        .def_readwrite("fileName", &CrashDump::CrashReport::ErrorSourceInfo::AssertContext::fileName, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, AssertContext, fileName))
+        .def_readwrite("functionName", &CrashDump::CrashReport::ErrorSourceInfo::AssertContext::functionName, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, AssertContext, functionName))
+        .def_readwrite("line", &CrashDump::CrashReport::ErrorSourceInfo::AssertContext::line, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, AssertContext, line))
+    ;
+
+    trapContext
+        .def(py::init<>())
+        .def_readwrite("trapNumber", &CrashDump::CrashReport::ErrorSourceInfo::TrapContext::trapNumber, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, TrapContext, trapNumber))
+        .def_readwrite("trapAddress", &CrashDump::CrashReport::ErrorSourceInfo::TrapContext::trapAddress, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, TrapContext, trapAddress))
+        .def_readwrite("trapName", &CrashDump::CrashReport::ErrorSourceInfo::TrapContext::trapName, DOC(dai, CrashDump, CrashReport, ErrorSourceInfo, TrapContext, trapName))
+    ;
+
+    threadCallstack
+        .def(py::init<>())
+        .def_readwrite("threadId", &CrashDump::CrashReport::ThreadCallstack::threadId, DOC(dai, CrashDump, CrashReport, ThreadCallstack, threadId))
+        .def_readwrite("threadName", &CrashDump::CrashReport::ThreadCallstack::threadName, DOC(dai, CrashDump, CrashReport, ThreadCallstack, threadName))
+        .def_readwrite("stackBottom", &CrashDump::CrashReport::ThreadCallstack::stackBottom, DOC(dai, CrashDump, CrashReport, ThreadCallstack, stackBottom))
+        .def_readwrite("stackTop", &CrashDump::CrashReport::ThreadCallstack::stackTop, DOC(dai, CrashDump, CrashReport, ThreadCallstack, stackTop))
+        .def_readwrite("stackPointer", &CrashDump::CrashReport::ThreadCallstack::stackPointer, DOC(dai, CrashDump, CrashReport, ThreadCallstack, stackPointer))
+        .def_readwrite("instructionPointer", &CrashDump::CrashReport::ThreadCallstack::instructionPointer, DOC(dai, CrashDump, CrashReport, ThreadCallstack, instructionPointer))
+        .def_readwrite("threadStatus", &CrashDump::CrashReport::ThreadCallstack::threadStatus, DOC(dai, CrashDump, CrashReport, ThreadCallstack, threadStatus))
+        .def_readwrite("callStack", &CrashDump::CrashReport::ThreadCallstack::callStack, DOC(dai, CrashDump, CrashReport, ThreadCallstack, callStack))
+    ;
+
+    callstackContext
+        .def(py::init<>())
+        .def_readwrite("callSite", &CrashDump::CrashReport::ThreadCallstack::CallstackContext::callSite, DOC(dai, CrashDump, CrashReport, ThreadCallstack, CallstackContext, callSite))
+        .def_readwrite("calledTarget", &CrashDump::CrashReport::ThreadCallstack::CallstackContext::calledTarget, DOC(dai, CrashDump, CrashReport, ThreadCallstack, CallstackContext, calledTarget))
+        .def_readwrite("framePointer", &CrashDump::CrashReport::ThreadCallstack::CallstackContext::framePointer, DOC(dai, CrashDump, CrashReport, ThreadCallstack, CallstackContext, framePointer))
+        .def_readwrite("context", &CrashDump::CrashReport::ThreadCallstack::CallstackContext::context, DOC(dai, CrashDump, CrashReport, ThreadCallstack, CallstackContext, context))
+    ;
+
     // Bind constructors
     bindConstructors<DeviceBase>(deviceBase);
     // Bind the rest
@@ -521,6 +583,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
         .def("getLogLevel", [](DeviceBase& d) { py::gil_scoped_release release; return d.getLogLevel(); }, DOC(dai, DeviceBase, getLogLevel))
         .def("setSystemInformationLoggingRate", [](DeviceBase& d, float hz) { py::gil_scoped_release release; d.setSystemInformationLoggingRate(hz); }, py::arg("rateHz"), DOC(dai, DeviceBase, setSystemInformationLoggingRate))
         .def("getSystemInformationLoggingRate", [](DeviceBase& d) { py::gil_scoped_release release; return d.getSystemInformationLoggingRate(); }, DOC(dai, DeviceBase, getSystemInformationLoggingRate))
+        .def("getCrashDump", [](DeviceBase& d) { py::gil_scoped_release release; return d.getCrashDump(); }, DOC(dai, DeviceBase, getCrashDump))
         .def("getConnectedCameras", [](DeviceBase& d) { py::gil_scoped_release release; return d.getConnectedCameras(); }, DOC(dai, DeviceBase, getConnectedCameras))
         .def("getConnectedCameraFeatures", [](DeviceBase& d) { py::gil_scoped_release release; return d.getConnectedCameraFeatures(); }, DOC(dai, DeviceBase, getConnectedCameraFeatures))
         .def("getCameraSensorNames", [](DeviceBase& d) { py::gil_scoped_release release; return d.getCameraSensorNames(); }, DOC(dai, DeviceBase, getCameraSensorNames))

--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -486,6 +486,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
     crashDump
         .def(py::init<>())
         .def_readwrite("crashReports", &CrashDump::crashReports, DOC(dai, CrashDump, crashReports))
+        .def_readwrite("depthaiCommitHash", &CrashDump::depthaiCommitHash, DOC(dai, CrashDump, depthaiCommitHash))
     ;
 
     crashReport


### PR DESCRIPTION
Outputs stack trace of threads from the device in case of a crash in json format, parsable by addr2line.
TODO: tool