### PR TITLE
ToF support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,9 +124,11 @@ pybind11_add_module(${TARGET_NAME}
     src/pipeline/node/IMUBindings.cpp
     src/pipeline/node/EdgeDetectorBindings.cpp
     src/pipeline/node/FeatureTrackerBindings.cpp
+    src/pipeline/node/ToFBindings.cpp
     src/pipeline/node/AprilTagBindings.cpp
     src/pipeline/node/DetectionParserBindings.cpp
     src/pipeline/node/WarpBindings.cpp
+    src/pipeline/node/ToFBindings.cpp
 
     src/pipeline/datatype/ADatatypeBindings.cpp
     src/pipeline/datatype/AprilTagConfigBindings.cpp
@@ -135,6 +137,7 @@ pybind11_add_module(${TARGET_NAME}
     src/pipeline/datatype/CameraControlBindings.cpp
     src/pipeline/datatype/EdgeDetectorConfigBindings.cpp
     src/pipeline/datatype/FeatureTrackerConfigBindings.cpp
+    src/pipeline/datatype/ToFConfigBindings.cpp
     src/pipeline/datatype/ImageManipConfigBindings.cpp
     src/pipeline/datatype/ImgDetectionsBindings.cpp
     src/pipeline/datatype/ImgFrameBindings.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,6 @@ pybind11_add_module(${TARGET_NAME}
     src/pipeline/node/IMUBindings.cpp
     src/pipeline/node/EdgeDetectorBindings.cpp
     src/pipeline/node/FeatureTrackerBindings.cpp
-    src/pipeline/node/ToFBindings.cpp
     src/pipeline/node/AprilTagBindings.cpp
     src/pipeline/node/DetectionParserBindings.cpp
     src/pipeline/node/WarpBindings.cpp

--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -21,6 +21,7 @@ void bind_spatiallocationcalculatordata(pybind11::module& m, void* pCallstack);
 void bind_stereodepthconfig(pybind11::module& m, void* pCallstack);
 void bind_systeminformation(pybind11::module& m, void* pCallstack);
 void bind_trackedfeatures(pybind11::module& m, void* pCallstack);
+void bind_tofconfig(pybind11::module& m, void* pCallstack);
 void bind_tracklets(pybind11::module& m, void* pCallstack);
 
 void DatatypeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
@@ -46,6 +47,7 @@ void DatatypeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
     callstack.push_front(bind_stereodepthconfig);
     callstack.push_front(bind_systeminformation);
     callstack.push_front(bind_trackedfeatures);
+    callstack.push_front(bind_tofconfig);
     callstack.push_front(bind_tracklets);
 }
 

--- a/src/pipeline/datatype/ImgFrameBindings.cpp
+++ b/src/pipeline/datatype/ImgFrameBindings.cpp
@@ -202,6 +202,9 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
                 break;
 
                 case ImgFrame::Type::RAW16:
+                case ImgFrame::Type::RAW14:
+                case ImgFrame::Type::RAW12:
+                case ImgFrame::Type::RAW10:
                     shape = {img.getHeight(), img.getWidth()};
                     dtype = py::dtype::of<uint16_t>();
                 break;
@@ -303,6 +306,9 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
 
                 case ImgFrame::Type::RAW8:
                 case ImgFrame::Type::RAW16:
+                case ImgFrame::Type::RAW14:
+                case ImgFrame::Type::RAW12:
+                case ImgFrame::Type::RAW10:
                 case ImgFrame::Type::GRAY8:
                 case ImgFrame::Type::GRAYF16:
                 default:

--- a/src/pipeline/datatype/ToFConfigBindings.cpp
+++ b/src/pipeline/datatype/ToFConfigBindings.cpp
@@ -58,8 +58,11 @@ void bind_tofconfig(pybind11::module& m, void* pCallstack){
     toFConfig
         .def(py::init<>())
         .def(py::init<std::shared_ptr<RawToFConfig>>())
-
+        
         .def("setDepthParams", static_cast<ToFConfig&(ToFConfig::*)(dai::ToFConfig::DepthParams)>(&ToFConfig::setDepthParams), py::arg("config"), DOC(dai, ToFConfig, setDepthParams, 2))
+        .def("setFreqModUsed", static_cast<ToFConfig&(ToFConfig::*)(dai::ToFConfig::DepthParams::TypeFMod)>(&ToFConfig::setFreqModUsed), DOC(dai, ToFConfig, setDepthParams, 2))
+        .def("setAvgPhaseShuffle", &ToFConfig::setAvgPhaseShuffle, DOC(dai, node, ToFConfig, setAvgPhaseShuffle))
+        .def("setMinAmplitude", &ToFConfig::setMinAmplitude, DOC(dai, node, ToFConfig, setMinAmplitude))
 
         .def("set", &ToFConfig::set, py::arg("config"), DOC(dai, ToFConfig, set))
         .def("get", &ToFConfig::get, DOC(dai, ToFConfig, get))

--- a/src/pipeline/datatype/ToFConfigBindings.cpp
+++ b/src/pipeline/datatype/ToFConfigBindings.cpp
@@ -59,10 +59,10 @@ void bind_tofconfig(pybind11::module& m, void* pCallstack){
         .def(py::init<>())
         .def(py::init<std::shared_ptr<RawToFConfig>>())
         
-        .def("setDepthParams", static_cast<ToFConfig&(ToFConfig::*)(dai::ToFConfig::DepthParams)>(&ToFConfig::setDepthParams), py::arg("config"), DOC(dai, ToFConfig, setDepthParams, 2))
-        .def("setFreqModUsed", static_cast<ToFConfig&(ToFConfig::*)(dai::ToFConfig::DepthParams::TypeFMod)>(&ToFConfig::setFreqModUsed), DOC(dai, ToFConfig, setDepthParams, 2))
-        .def("setAvgPhaseShuffle", &ToFConfig::setAvgPhaseShuffle, DOC(dai, node, ToFConfig, setAvgPhaseShuffle))
-        .def("setMinAmplitude", &ToFConfig::setMinAmplitude, DOC(dai, node, ToFConfig, setMinAmplitude))
+        .def("setDepthParams", static_cast<ToFConfig&(ToFConfig::*)(dai::ToFConfig::DepthParams)>(&ToFConfig::setDepthParams), py::arg("config"), DOC(dai, ToFConfig, setDepthParams))
+        .def("setFreqModUsed", static_cast<ToFConfig&(ToFConfig::*)(dai::ToFConfig::DepthParams::TypeFMod)>(&ToFConfig::setFreqModUsed), DOC(dai, ToFConfig, setFreqModUsed))
+        .def("setAvgPhaseShuffle", &ToFConfig::setAvgPhaseShuffle, DOC(dai, ToFConfig, setAvgPhaseShuffle))
+        .def("setMinAmplitude", &ToFConfig::setMinAmplitude, DOC(dai, ToFConfig, setMinAmplitude))
 
         .def("set", &ToFConfig::set, py::arg("config"), DOC(dai, ToFConfig, set))
         .def("get", &ToFConfig::get, DOC(dai, ToFConfig, get))

--- a/src/pipeline/datatype/ToFConfigBindings.cpp
+++ b/src/pipeline/datatype/ToFConfigBindings.cpp
@@ -1,0 +1,71 @@
+#include "DatatypeBindings.hpp"
+#include "pipeline/CommonBindings.hpp"
+#include <unordered_map>
+#include <memory>
+
+// depthai
+#include "depthai/pipeline/datatype/ToFConfig.hpp"
+
+//pybind
+#include <pybind11/chrono.h>
+#include <pybind11/numpy.h>
+
+// #include "spdlog/spdlog.h"
+
+void bind_tofconfig(pybind11::module& m, void* pCallstack){
+
+    using namespace dai;
+
+    py::class_<RawToFConfig, RawBuffer, std::shared_ptr<RawToFConfig>> rawToFConfig(m, "RawToFConfig", DOC(dai, RawToFConfig));
+    py::class_<RawToFConfig::DepthParams> depthParams(rawToFConfig, "DepthParams", DOC(dai, RawToFConfig, DepthParams));
+    py::enum_<RawToFConfig::DepthParams::TypeFMod> depthParamsTypeFMod(depthParams, "TypeFMod", DOC(dai, RawToFConfig, DepthParams, TypeFMod));
+    py::class_<ToFConfig, Buffer, std::shared_ptr<ToFConfig>> toFConfig(m, "ToFConfig", DOC(dai, ToFConfig));
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+    // Metadata / raw
+    rawToFConfig
+        .def(py::init<>())
+        .def_readwrite("depthParams", &RawToFConfig::depthParams, DOC(dai, RawToFConfig, depthParams))
+        ;
+
+    depthParamsTypeFMod
+        .value("ALL", RawToFConfig::DepthParams::TypeFMod::F_MOD_ALL)
+        .value("MIN", RawToFConfig::DepthParams::TypeFMod::F_MOD_MIN)
+        .value("MAX", RawToFConfig::DepthParams::TypeFMod::F_MOD_MAX)
+    ;
+
+    depthParams
+        .def(py::init<>())
+        .def_readwrite("enable", &RawToFConfig::DepthParams::enable, DOC(dai, RawToFConfig, DepthParams, enable))
+        .def_readwrite("freqModUsed", &RawToFConfig::DepthParams::freqModUsed, DOC(dai, RawToFConfig, DepthParams, freqModUsed))
+        .def_readwrite("avgPhaseShuffle", &RawToFConfig::DepthParams::avgPhaseShuffle, DOC(dai, RawToFConfig, DepthParams, avgPhaseShuffle))
+        .def_readwrite("minimumAmplitude", &RawToFConfig::DepthParams::minimumAmplitude, DOC(dai, RawToFConfig, DepthParams, minimumAmplitude))
+        ;
+
+    // Message
+    toFConfig
+        .def(py::init<>())
+        .def(py::init<std::shared_ptr<RawToFConfig>>())
+
+        .def("setDepthParams", static_cast<ToFConfig&(ToFConfig::*)(dai::ToFConfig::DepthParams)>(&ToFConfig::setDepthParams), py::arg("config"), DOC(dai, ToFConfig, setDepthParams, 2))
+
+        .def("set", &ToFConfig::set, py::arg("config"), DOC(dai, ToFConfig, set))
+        .def("get", &ToFConfig::get, DOC(dai, ToFConfig, get))
+        ;
+
+    // add aliases
+    m.attr("ToFConfig").attr("DepthParams") = m.attr("RawToFConfig").attr("DepthParams");
+
+}

--- a/src/pipeline/node/CameraBindings.cpp
+++ b/src/pipeline/node/CameraBindings.cpp
@@ -159,6 +159,7 @@ void bind_camera(pybind11::module& m, void* pCallstack){
         .def("setCalibrationAlpha", &Camera::setCalibrationAlpha, py::arg("alpha"), DOC(dai, node, Camera, setCalibrationAlpha))
         .def("getCalibrationAlpha", &Camera::getCalibrationAlpha, DOC(dai, node, Camera, getCalibrationAlpha))
 
+        .def("setRawOutputPacked", &Camera::setRawOutputPacked, py::arg("packed"), DOC(dai, node, Camera, setRawOutputPacked))
         ;
     // ALIAS
     daiNodeModule.attr("Camera").attr("Properties") = cameraProperties;

--- a/src/pipeline/node/ColorCameraBindings.cpp
+++ b/src/pipeline/node/ColorCameraBindings.cpp
@@ -188,6 +188,8 @@ void bind_colorcamera(pybind11::module& m, void* pCallstack){
         .def("getIspNumFramesPool", &ColorCamera::getIspNumFramesPool, DOC(dai, node, ColorCamera, getIspNumFramesPool))
         .def("setCamera", &ColorCamera::setCamera, py::arg("name"), DOC(dai, node, ColorCamera, setCamera))
         .def("getCamera", &ColorCamera::getCamera, DOC(dai, node, ColorCamera, getCamera))
+
+        .def("setRawOutputPacked", &ColorCamera::setRawOutputPacked, py::arg("packed"), DOC(dai, node, ColorCamera, setRawOutputPacked))
         ;
     // ALIAS
     daiNodeModule.attr("ColorCamera").attr("Properties") = colorCameraProperties;

--- a/src/pipeline/node/MonoCameraBindings.cpp
+++ b/src/pipeline/node/MonoCameraBindings.cpp
@@ -92,6 +92,8 @@ void bind_monocamera(pybind11::module& m, void* pCallstack){
         .def("getRawNumFramesPool", &MonoCamera::getRawNumFramesPool, DOC(dai, node, MonoCamera, getRawNumFramesPool))
         .def("setCamera", &MonoCamera::setCamera, py::arg("name"), DOC(dai, node, MonoCamera, setCamera))
         .def("getCamera", &MonoCamera::getCamera, DOC(dai, node, MonoCamera, getCamera))
+
+        .def("setRawOutputPacked", &MonoCamera::setRawOutputPacked, py::arg("packed"), DOC(dai, node, MonoCamera, setRawOutputPacked))
         ;
     // ALIAS
     daiNodeModule.attr("MonoCamera").attr("Properties") = monoCameraProperties;

--- a/src/pipeline/node/NodeBindings.cpp
+++ b/src/pipeline/node/NodeBindings.cpp
@@ -114,6 +114,7 @@ void bind_edgedetector(pybind11::module& m, void* pCallstack);
 void bind_featuretracker(pybind11::module& m, void* pCallstack);
 void bind_apriltag(pybind11::module& m, void* pCallstack);
 void bind_detectionparser(pybind11::module& m, void* pCallstack);
+void bind_tof(pybind11::module& m, void* pCallstack);
 
 void NodeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
     // Bind Node et al
@@ -143,6 +144,7 @@ void NodeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
     callstack.push_front(bind_featuretracker);
     callstack.push_front(bind_apriltag);
     callstack.push_front(bind_detectionparser);
+    callstack.push_front(bind_tof);
 }
 
 void NodeBindings::bind(pybind11::module& m, void* pCallstack){

--- a/src/pipeline/node/ToFBindings.cpp
+++ b/src/pipeline/node/ToFBindings.cpp
@@ -29,13 +29,13 @@ void bind_tof(pybind11::module& m, void* pCallstack){
 
     // Properties
     tofProperties
-        .def_readwrite("initialConfig", &ToFProperties::initialConfig)
+        .def_readwrite("initialConfig", &ToFProperties::initialConfig, DOC(dai, ToFProperties, initialConfig))
         ;
 
     // Node
     tof
-        .def_readonly("input", &ToF::input, DOC(dai, node, ToF, input), DOC(dai, node, ToF, input))
         .def_readonly("inputConfig", &ToF::inputConfig, DOC(dai, node, ToF, inputConfig), DOC(dai, node, ToF, inputConfig))
+        .def_readonly("input", &ToF::input, DOC(dai, node, ToF, input), DOC(dai, node, ToF, input))
         .def_readonly("depth", &ToF::depth, DOC(dai, node, ToF, depth), DOC(dai, node, ToF, depth))
         .def_readonly("amplitude", &ToF::amplitude, DOC(dai, node, ToF, amplitude), DOC(dai, node, ToF, amplitude))
         .def_readonly("error", &ToF::error, DOC(dai, node, ToF, error), DOC(dai, node, ToF, error))

--- a/src/pipeline/node/ToFBindings.cpp
+++ b/src/pipeline/node/ToFBindings.cpp
@@ -1,0 +1,47 @@
+#include "NodeBindings.hpp"
+#include "Common.hpp"
+
+#include "depthai/pipeline/Pipeline.hpp"
+#include "depthai/pipeline/Node.hpp"
+#include "depthai/pipeline/node/ToF.hpp"
+
+void bind_tof(pybind11::module& m, void* pCallstack){
+
+    using namespace dai;
+    using namespace dai::node;
+
+    // Node and Properties declare upfront
+    py::class_<ToFProperties> tofProperties(m, "ToFProperties", DOC(dai, ToFProperties));
+    auto tof = ADD_NODE(ToF);
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+    // Properties
+    tofProperties
+        .def_readwrite("initialConfig", &ToFProperties::initialConfig)
+        ;
+
+    // Node
+    tof
+        .def_readonly("input", &ToF::input, DOC(dai, node, ToF, input), DOC(dai, node, ToF, input))
+        .def_readonly("inputConfig", &ToF::inputConfig, DOC(dai, node, ToF, inputConfig), DOC(dai, node, ToF, inputConfig))
+        .def_readonly("depth", &ToF::depth, DOC(dai, node, ToF, depth), DOC(dai, node, ToF, depth))
+        .def_readonly("amplitude", &ToF::amplitude, DOC(dai, node, ToF, amplitude), DOC(dai, node, ToF, amplitude))
+        .def_readonly("error", &ToF::error, DOC(dai, node, ToF, error), DOC(dai, node, ToF, error))
+        .def_readonly("initialConfig", &ToF::initialConfig, DOC(dai, node, ToF, initialConfig), DOC(dai, node, ToF, initialConfig))
+    ;
+    // ALIAS
+    daiNodeModule.attr("ToF").attr("Properties") = tofProperties;
+
+}

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -36,6 +36,7 @@ import os
 #os.environ["DEPTHAI_LEVEL"] = "debug"
 
 import cv2
+import numpy as np
 import argparse
 import collections
 import time
@@ -80,6 +81,8 @@ parser.add_argument('-tun', '--camera-tuning', type=Path,
                     help="Path to custom camera tuning database")
 parser.add_argument('-d', '--device', default="", type=str,
                     help="Optional MX ID of the device to connect to.")
+parser.add_argument('-raw', '--enable-raw', default=False, action="store_true",
+                    help='Enable the RAW camera streams')
 
 parser.add_argument('-ctimeout', '--connection-timeout', default=30000,
                     help="Connection timeout in ms. Default: %(default)s (sets DEPTHAI_CONNECTION_TIMEOUT environment variable)")
@@ -178,9 +181,12 @@ control.setStreamName('control')
 
 cam = {}
 xout = {}
+xout_raw = {}
+streams = []
 for c in cam_list:
     xout[c] = pipeline.createXLinkOut()
     xout[c].setStreamName(c)
+    streams.append(c)
     if cam_type_color[c]:
         cam[c] = pipeline.createColorCamera()
         cam[c].setResolution(color_res_opts[args.color_resolution])
@@ -205,6 +211,15 @@ for c in cam_list:
         cam[c].setImageOrientation(dai.CameraImageOrientation.ROTATE_180_DEG)
     cam[c].setFps(args.fps)
     cam[c].setIsp3aFps(args.isp3afps)
+
+    if args.enable_raw:
+        raw_name = 'raw_' + c
+        xout_raw[c] = pipeline.create(dai.node.XLinkOut)
+        xout_raw[c].setStreamName(raw_name)
+        if args.enable_raw:
+            streams.append(raw_name)
+        cam[c].raw.link(xout_raw[c].input)
+        # to be added cam[c].setRawOutputPacked(False)
 
 if args.camera_tuning:
     pipeline.setCameraTuningBlobPath(str(args.camera_tuning))
@@ -232,6 +247,8 @@ with dai.Device(*dai_device_args) as device:
         print('auto ' if p.hasAutofocus else 'fixed', '- ', end='')
         print(*[type.name for type in p.supportedTypes])
         cam_name[p.socket.name] = p.sensorName
+        if args.enable_raw:
+            cam_name['raw_'+p.socket.name] = p.sensorName
 
     print('USB speed:', device.getUsbSpeed().name)
 
@@ -240,7 +257,7 @@ with dai.Device(*dai_device_args) as device:
     q = {}
     fps_host = {}  # FPS computed based on the time we receive frames in app
     fps_capt = {}  # FPS computed based on capture timestamps from device
-    for c in cam_list:
+    for c in streams:
         q[c] = device.getOutputQueue(name=c, maxSize=4, blocking=False)
         # The OpenCV window resize may produce some artifacts
         if args.resizable_windows:
@@ -299,7 +316,7 @@ with dai.Device(*dai_device_args) as device:
 
     capture_list = []
     while True:
-        for c in cam_list:
+        for c in streams:
             try:
                 pkt = q[c].tryGet()
             except Exception as e:
@@ -308,25 +325,44 @@ with dai.Device(*dai_device_args) as device:
             if pkt is not None:
                 fps_host[c].update()
                 fps_capt[c].update(pkt.getTimestamp().total_seconds())
+                width, height = pkt.getWidth(), pkt.getHeight()
                 frame = pkt.getCvFrame()
-                if c in capture_list:
-                    width, height = pkt.getWidth(), pkt.getHeight()
-                    capture_file_name = ('capture_' + c + '_' + cam_name[cam_socket_opts[c].name]
-                                         + '_' + str(width) + 'x' + str(height)
-                                         + '_exp_' +
-                                         str(int(
-                                             pkt.getExposureTime().total_seconds()*1e6))
-                                         + '_iso_' + str(pkt.getSensitivity())
-                                         + '_lens_' +
-                                         str(pkt.getLensPosition())
-                                         + '_' + capture_time
-                                         + '_' + str(pkt.getSequenceNum())
-                                         + ".png"
-                                         )
-                    print("\nSaving:", capture_file_name)
-                    cv2.imwrite(capture_file_name, frame)
+                capture = c in capture_list
+                if capture:
+                    capture_file_info = ('capture_' + c + '_' + cam_name[c]
+                         + '_' + str(width) + 'x' + str(height)
+                         + '_exp_' + str(int(pkt.getExposureTime().total_seconds()*1e6))
+                         + '_iso_' + str(pkt.getSensitivity())
+                         + '_lens_' + str(pkt.getLensPosition())
+                         + '_' + capture_time
+                         + '_' + str(pkt.getSequenceNum())
+                        )
                     capture_list.remove(c)
-
+                    print()
+                if c.startswith('raw_'):
+                    if capture:
+                        filename = capture_file_info + '_10bit.bw'
+                        print('Saving:', filename)
+                        frame.tofile(filename)
+                    # Full range for display, use bits [15:6] of the 16-bit pixels
+                    frame = frame * (1 << 6)
+                    # Debayer color for preview/png
+                    if cam_type_color[c.split('_')[-1]]:
+                        # See this for the ordering, at the end of page:
+                        # https://docs.opencv.org/4.5.1/de/d25/imgproc_color_conversions.html
+                        # TODO add bayer order to ImgFrame getType()
+                        frame = cv2.cvtColor(frame, cv2.COLOR_BayerGB2BGR)
+                else:
+                    # Save YUV too, but only when RAW is also enabled (for tuning purposes)
+                    if capture and args.enable_raw:
+                        payload = pkt.getData()
+                        filename = capture_file_info + '_P420.yuv'
+                        print('Saving:', filename)
+                        payload.tofile(filename)
+                if capture:
+                    filename = capture_file_info + '.png'
+                    print('Saving:', filename)
+                    cv2.imwrite(filename, frame)
                 cv2.imshow(c, frame)
         print("\rFPS:",
               *["{:6.2f}|{:6.2f}".format(fps_host[c].get(),
@@ -337,7 +373,7 @@ with dai.Device(*dai_device_args) as device:
         if key == ord('q'):
             break
         elif key == ord('c'):
-            capture_list = cam_list.copy()
+            capture_list = streams.copy()
             capture_time = time.strftime('%Y%m%d_%H%M%S')
         elif key == ord('t'):
             print("Autofocus trigger (and disable continuous)")

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -428,6 +428,10 @@ with dai.Device(*dai_device_args) as device:
             print("ToF toggling f_mod value to:", f_mod)
             tofConfig.depthParams.freqModUsed = f_mod
             tofCfgQueue.send(tofConfig)
+        elif key == ord('h'):
+            tofConfig.depthParams.avgPhaseShuffle = not tofConfig.depthParams.avgPhaseShuffle
+            print("ToF toggling avgPhaseShuffle value to:", tofConfig.depthParams.avgPhaseShuffle)
+            tofCfgQueue.send(tofConfig)
         elif key == ord('t'):
             print("Autofocus trigger (and disable continuous)")
             ctrl = dai.CameraControl()

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -45,7 +45,7 @@ import time
 from itertools import cycle
 from pathlib import Path
 import sys
-import cam_test_gui
+#import cam_test_gui
 import signal
 
 
@@ -181,6 +181,9 @@ pipeline = dai.Pipeline()
 control = pipeline.createXLinkIn()
 control.setStreamName('control')
 
+xinTofConfig = pipeline.createXLinkIn()
+xinTofConfig.setStreamName('tofConfig')
+
 cam = {}
 tof = {}
 xout = {}
@@ -199,6 +202,11 @@ for c in cam_list:
             tof[c] = pipeline.create(dai.node.ToF)
             cam[c].raw.link(tof[c].input)
             tof[c].depth.link(xout[c].input)
+            xinTofConfig.out.link(tof[c].inputConfig)
+            tofConfig = tof[c].initialConfig.get()
+            tofConfig.setFreqModUsed(dai.ToFConfig.DepthParams.TypeFMod.F_MOD_MIN)
+            tofConfig.SetAvgPhaseShuffle(True)
+            tofConfig.setMinAmplitude(20.0)
     elif cam_type_color[c]:
         cam[c] = pipeline.createColorCamera()
         cam[c].setResolution(color_res_opts[args.color_resolution])
@@ -230,7 +238,7 @@ for c in cam_list:
         xout_raw[c] = pipeline.create(dai.node.XLinkOut)
         xout_raw[c].setStreamName(raw_name)
         streams.append(raw_name)
-        cam[c].raw.link(xout_raw[c].input)
+        tof[c].amplitude.link(xout_raw[c].input)
         cam[c].setRawOutputPacked(False)
 
 if args.camera_tuning:

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -212,7 +212,8 @@ for c in cam_list:
     if rotate[c]:
         cam[c].setImageOrientation(dai.CameraImageOrientation.ROTATE_180_DEG)
     cam[c].setFps(args.fps)
-    cam[c].setIsp3aFps(args.isp3afps)
+    if args.isp3afps:
+        cam[c].setIsp3aFps(args.isp3afps)
 
     if args.enable_raw:
         raw_name = 'raw_' + c
@@ -221,7 +222,7 @@ for c in cam_list:
         if args.enable_raw:
             streams.append(raw_name)
         cam[c].raw.link(xout_raw[c].input)
-        # to be added cam[c].setRawOutputPacked(False)
+        cam[c].setRawOutputPacked(False)
 
 if args.camera_tuning:
     pipeline.setCameraTuningBlobPath(str(args.camera_tuning))
@@ -355,7 +356,11 @@ with dai.Device(*dai_device_args) as device:
                         print('Saving:', filename)
                         frame.tofile(filename)
                     # Full range for display, use bits [15:6] of the 16-bit pixels
-                    frame = frame * (1 << 6)
+                    type = pkt.getType()
+                    multiplier = 1
+                    if type == dai.ImgFrame.Type.RAW10: multiplier = (1 << (16-10))
+                    if type == dai.ImgFrame.Type.RAW12: multiplier = (1 << (16-4))
+                    frame = frame * multiplier
                     # Debayer color for preview/png
                     if cam_type_color[c.split('_')[-1]]:
                         # See this for the ordering, at the end of page:

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -182,14 +182,24 @@ control = pipeline.createXLinkIn()
 control.setStreamName('control')
 
 cam = {}
+tof = {}
 xout = {}
 xout_raw = {}
 streams = []
 for c in cam_list:
+    tofEnableRaw = False
     xout[c] = pipeline.createXLinkOut()
     xout[c].setStreamName(c)
     streams.append(c)
-    if cam_type_color[c]:
+    if cam_type_tof[c]:
+        cam[c] = pipeline.create(dai.node.ColorCamera)  # .Camera
+        if args.tof_raw:
+            tofEnableRaw = True
+        else:
+            tof[c] = pipeline.create(dai.node.ToF)
+            cam[c].raw.link(tof[c].input)
+            tof[c].depth.link(xout[c].input)
+    elif cam_type_color[c]:
         cam[c] = pipeline.createColorCamera()
         cam[c].setResolution(color_res_opts[args.color_resolution])
         cam[c].setIspScale(1, args.isp_downscale)
@@ -215,12 +225,11 @@ for c in cam_list:
     if args.isp3afps:
         cam[c].setIsp3aFps(args.isp3afps)
 
-    if args.enable_raw:
+    if args.enable_raw or tofEnableRaw:
         raw_name = 'raw_' + c
         xout_raw[c] = pipeline.create(dai.node.XLinkOut)
         xout_raw[c].setStreamName(raw_name)
-        if args.enable_raw:
-            streams.append(raw_name)
+        streams.append(raw_name)
         cam[c].raw.link(xout_raw[c].input)
         cam[c].setRawOutputPacked(False)
 
@@ -331,6 +340,14 @@ with dai.Device(*dai_device_args) as device:
                 fps_capt[c].update(pkt.getTimestamp().total_seconds())
                 width, height = pkt.getWidth(), pkt.getHeight()
                 frame = pkt.getCvFrame()
+                if cam_type_tof[c.split('_')[-1]] and not c.startswith('raw_'):
+                    if args.tof_cm:
+                        # pixels represent `cm`, capped to 255. Value can be checked hovering the mouse
+                        frame = (frame // 10).clip(0, 255).astype(np.uint8)
+                    else:
+                        frame = (frame.view(np.int16).astype(float))
+                        frame = cv2.normalize(frame, frame, alpha=255, beta=0, norm_type=cv2.NORM_MINMAX, dtype=cv2.CV_8U)
+                        frame = cv2.applyColorMap(frame, jet_custom)
                 if show:
                     txt = f"[{c:5}, {pkt.getSequenceNum():4}] "
                     txt += f"Exp: {pkt.getExposureTime().total_seconds()*1000:6.3f} ms, "
@@ -361,7 +378,7 @@ with dai.Device(*dai_device_args) as device:
                     if type == dai.ImgFrame.Type.RAW10: multiplier = (1 << (16-10))
                     if type == dai.ImgFrame.Type.RAW12: multiplier = (1 << (16-4))
                     frame = frame * multiplier
-                    # Debayer color for preview/png
+                    # Debayer as color for preview/png
                     if cam_type_color[c.split('_')[-1]]:
                         # See this for the ordering, at the end of page:
                         # https://docs.opencv.org/4.5.1/de/d25/imgproc_color_conversions.html

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -189,6 +189,7 @@ tof = {}
 xout = {}
 xout_raw = {}
 streams = []
+tofConfig = {}
 for c in cam_list:
     tofEnableRaw = False
     xout[c] = pipeline.createXLinkOut()
@@ -204,9 +205,10 @@ for c in cam_list:
             tof[c].depth.link(xout[c].input)
             xinTofConfig.out.link(tof[c].inputConfig)
             tofConfig = tof[c].initialConfig.get()
-            tofConfig.setFreqModUsed(dai.ToFConfig.DepthParams.TypeFMod.F_MOD_MIN)
-            tofConfig.SetAvgPhaseShuffle(True)
-            tofConfig.setMinAmplitude(20.0)
+            tofConfig.depthParams.freqModUsed = dai.RawToFConfig.DepthParams.TypeFMod.MIN
+            tofConfig.depthParams.avgPhaseShuffle = False
+            tofConfig.depthParams.minimumAmplitude = 3.0
+            tof[c].initialConfig.set(tofConfig)
     elif cam_type_color[c]:
         cam[c] = pipeline.createColorCamera()
         cam[c].setResolution(color_res_opts[args.color_resolution])
@@ -287,6 +289,7 @@ with dai.Device(*dai_device_args) as device:
         fps_capt[c] = FPS()
 
     controlQueue = device.getInputQueue('control')
+    tofCfgQueue = device.getInputQueue('tofConfig')
 
     # Manual exposure/focus set step
     EXP_STEP = 500  # us
@@ -331,6 +334,7 @@ with dai.Device(*dai_device_args) as device:
     chroma_denoise = 0
     control = 'none'
     show = False
+    tof_amp_min = tofConfig.depthParams.minimumAmplitude
 
     print("Cam:", *['     ' + c.ljust(8)
           for c in cam_list], "[host | capture timestamp]")
@@ -419,6 +423,11 @@ with dai.Device(*dai_device_args) as device:
         elif key == ord('c'):
             capture_list = streams.copy()
             capture_time = time.strftime('%Y%m%d_%H%M%S')
+        elif key == ord('g'):
+            f_mod = dai.RawToFConfig.DepthParams.TypeFMod.MAX if tofConfig.depthParams.freqModUsed  == dai.RawToFConfig.DepthParams.TypeFMod.MIN else dai.RawToFConfig.DepthParams.TypeFMod.MIN
+            print("ToF toggling f_mod value to:", f_mod)
+            tofConfig.depthParams.freqModUsed = f_mod
+            tofCfgQueue.send(tofConfig)
         elif key == ord('t'):
             print("Autofocus trigger (and disable continuous)")
             ctrl = dai.CameraControl()
@@ -493,7 +502,7 @@ with dai.Device(*dai_device_args) as device:
             if floodIntensity < 0:
                 floodIntensity = 0
             device.setIrFloodLightBrightness(floodIntensity)
-        elif key >= 0 and chr(key) in '34567890[]':
+        elif key >= 0 and chr(key) in '34567890[]p':
             if key == ord('3'):
                 control = 'awb_mode'
             elif key == ord('4'):
@@ -514,6 +523,8 @@ with dai.Device(*dai_device_args) as device:
                 control = 'luma_denoise'
             elif key == ord(']'):
                 control = 'chroma_denoise'
+            elif key == ord('p'):
+                control = 'tof_amplitude_min'
             print("Selected control:", control)
         elif key in [ord('-'), ord('_'), ord('+'), ord('=')]:
             change = 0
@@ -564,4 +575,9 @@ with dai.Device(*dai_device_args) as device:
                 chroma_denoise = clamp(chroma_denoise + change, 0, 4)
                 print("Chroma denoise:", chroma_denoise)
                 ctrl.setChromaDenoise(chroma_denoise)
+            elif control == 'tof_amplitude_min':
+                amp_min = clamp(tofConfig.depthParams.minimumAmplitude + change, 0, 50)
+                print("Setting min amplitude(confidence) to:", amp_min)
+                tofConfig.depthParams.minimumAmplitude = amp_min
+                tofCfgQueue.send(tofConfig)
             controlQueue.send(ctrl)

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -30,6 +30,8 @@ Other controls:
 For the 'Select control: ...' options, use these keys to modify the value:
   '-' or '_' to decrease
   '+' or '=' to increase
+
+'/' to toggle printing camera settings: exposure, ISO, lens position, color temperature
 """
 
 import os
@@ -310,6 +312,7 @@ with dai.Device(*dai_device_args) as device:
     luma_denoise = 0
     chroma_denoise = 0
     control = 'none'
+    show = False
 
     print("Cam:", *['     ' + c.ljust(8)
           for c in cam_list], "[host | capture timestamp]")
@@ -327,6 +330,13 @@ with dai.Device(*dai_device_args) as device:
                 fps_capt[c].update(pkt.getTimestamp().total_seconds())
                 width, height = pkt.getWidth(), pkt.getHeight()
                 frame = pkt.getCvFrame()
+                if show:
+                    txt = f"[{c:5}, {pkt.getSequenceNum():4}] "
+                    txt += f"Exp: {pkt.getExposureTime().total_seconds()*1000:6.3f} ms, "
+                    txt += f"ISO: {pkt.getSensitivity():4}, "
+                    txt += f"Lens pos: {pkt.getLensPosition():3}, "
+                    txt += f"Color temp: {pkt.getColorTemperature()} K"
+                    print(txt)
                 capture = c in capture_list
                 if capture:
                     capture_file_info = ('capture_' + c + '_' + cam_name[c]
@@ -365,13 +375,17 @@ with dai.Device(*dai_device_args) as device:
                     cv2.imwrite(filename, frame)
                 cv2.imshow(c, frame)
         print("\rFPS:",
-              *["{:6.2f}|{:6.2f}".format(fps_host[c].get(),
-                                         fps_capt[c].get()) for c in cam_list],
-              end='', flush=True)
+              *["{:6.2f}|{:6.2f}".format(fps_host[c].get(), fps_capt[c].get()) for c in cam_list],
+              end=' ', flush=True)
+        if show: print()
 
         key = cv2.waitKey(1)
         if key == ord('q'):
             break
+        elif key == ord('/'):
+            show = not show
+            # Print empty string as FPS status new-line separator
+            print("" if show else "Printing camera settings: OFF")
         elif key == ord('c'):
             capture_list = streams.copy()
             capture_time = time.strftime('%Y%m%d_%H%M%S')


### PR DESCRIPTION
- new `ToF` node with initial/runtime `ToFConfig`
- raw data packing configuration for [Color/Mono]/Camera: `setRawOutputPacked(packed)`
- opencv/ImgFrame: handle `RAW10`/`RAW12`/`RAW14` frame types (non-packed) like `RAW16`

- `utilities/cam_test.py` additions:
  - `-cams` argument `,t`/`,tof` to add ToF decoding for relevant cameras, e.g.: `-cams cama,t`
  - `-raw` option to stream unprocessed frames as well . Use `C` for capture, it saves both PNGs and raw header-less frames. Can convert headerless RAW to DNG with this script: https://gist.github.com/alex-luxonis/a60d2d29692b74491838e72b69bdddc2   
  - ToF decoding config at runtime using keys:
    - `G` to toggle light modulation frequency
    - `H` to toggle frame averaging
    - `P` to select the control for minimum amplitude filtering (like confidence threshold), then adjust with `-`/`+`
  - other ToF options:
    - `-tofraw` to stream just ToF raw, without depth decoding (`-raw` to have both)
    - `-tofcm` - show ToF depth output in centimeters, capped to 255. By default it displays colorized depth
    `-tofamp` - stream also ToF amplitude output. This could be useful for calibration
  - `/` key to toggle printing per-frame camera settings (exposure, ISO, lens position, color temperature)
 
Related: https://github.com/luxonis/depthai-core/pull/826