### PR TITLE
added child run id to summary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -540,14 +540,33 @@ jobs:
           event-type: depthai-python-release
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
 
+  # notify_hil_workflow_linux_x86_64:
+  #   needs: [build-linux-x86_64]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Repository Dispatch
+  #       uses: peter-evans/repository-dispatch@v2
+  #       with:
+  #         token: ${{ secrets.HIL_CORE_DISPATCH_TOKEN }}
+  #         repository: luxonis/depthai-core-hil-tests
+  #         event-type: python-hil-event
+  #         client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+
   notify_hil_workflow_linux_x86_64:
     needs: [build-linux-x86_64]
     runs-on: ubuntu-latest
     steps:
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+      - name: Dispatch an action and get the run ID
+        uses: codex-/return-dispatch@v1
+        id: return_dispatch
         with:
-          token: ${{ secrets.HIL_CORE_DISPATCH_TOKEN }}
-          repository: luxonis/depthai-core-hil-tests
-          event-type: python-hil-event
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          token: ${{ secrets.HIL_CORE_DISPATCH_TOKEN }} # Note this is NOT GITHUB_TOKEN but a PAT 
+          ref: main # or refs/heads/target_branch
+          repo: depthai-core-hil-tests
+          owner: luxonis
+          workflow: regression_test.yml
+          workflow_inputs: '{"commit": "${{ github.ref }}", "sha": "${{ github.sha }}", "parent_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' 
+          workflow_timeout_seconds: 120 # Default: 300
+
+      - name: Release
+        run: echo "https://github.com/luxonis/depthai-core-hil-tests/actions/runs/${{steps.return_dispatch.outputs.run_id}}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Changed the way hil test runs are triggered in order to get the child action run ID. I also added a summary with a link to the before mentioned run.