### PR TITLE
Raspberry Pi Zero compatible wheels (armv6l)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,11 +158,8 @@ jobs:
         run: for whl in wheelhouse/*.whl; do auditwheel repair "$whl" --plat linux_armv7l -w wheelhouse/audited/; done
       - name: Install tweaked auditwheel and add armv6l tag
         run: |
-          python3 -m venv newauditvenv
-          source newauditvenv/bin/activate
           python3 -m pip install git+https://github.com/luxonis/auditwheel@main
           for whl in wheelhouse/*.whl; do python3 -m auditwheel addtag -t linux_armv7l linux_armv6l -w wheelhouse/postaudited/ "$whl"; done
-          deactivate
       - name: Archive wheel artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,11 +156,18 @@ jobs:
         run: python3 -m pip wheel . -w ./wheelhouse/ --verbose
       - name: Auditing wheel
         run: for whl in wheelhouse/*.whl; do auditwheel repair "$whl" --plat linux_armv7l -w wheelhouse/audited/; done
+      - name: Install tweaked auditwheel and add armv6l tag
+        run: |
+          python3 -m venv newauditvenv
+          source newauditvenv/bin/activate
+          python3 -m pip install git+https://github.com/luxonis/auditwheel@main
+          for whl in wheelhouse/*.whl; do python3 -m auditwheel addtag -t linux_armv7l linux_armv6l -w wheelhouse/postaudited/ "$whl"; done
+          deactivate
       - name: Archive wheel artifacts
         uses: actions/upload-artifact@v3
         with:
           name: audited-wheels
-          path: wheelhouse/audited/
+          path: wheelhouse/postaudited/
       - name: Deploy wheels to artifactory (if not a release)
         if: startsWith(github.ref, 'refs/tags/v') != true
         run: bash ./ci/upload-artifactory.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "mypy==1.3.0", "cmake==3.25"]
+requires = ["setuptools", "wheel", "mypy<=1.3.0", "cmake==3.25"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "mypy", "cmake==3.25"]
+requires = ["setuptools", "wheel", "mypy==1.3.0", "cmake==3.25"]


### PR DESCRIPTION
- Modifies tag on armv7l wheels to armv6l (as compilers on RPi already compile targeting armv6 arch), and prepares these to be uploaded to pypi as well.
- Fixes mypy issue, by specifying a specific version instead