### PR TITLE
Removed custom libclang for rtd build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,12 +22,13 @@ subprocess.check_call(['make', '-j'], cwd=tmpdir+'/libusb-1.0.24')
 subprocess.check_call(['make', 'install'], cwd=tmpdir+'/libusb-1.0.24')
 env['PATH'] = tmpdir+'/libusb/include:'+tmpdir+'/libusb/lib'+':'+env['PATH']
 
-# libclang
-subprocess.check_call(['wget', 'https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/libclang-11_manylinux2014_x86_64.tar.xz'], cwd=tmpdir)
-subprocess.check_call(['mkdir', '-p', 'libclang'], cwd=tmpdir)
-subprocess.check_call(['tar', 'xf', 'libclang-11_manylinux2014_x86_64.tar.xz', '-C', tmpdir+'/libclang/'], cwd=tmpdir)
-env['LIBCLANG_PATH'] = tmpdir+'/libclang/usr/lib/llvm-11/lib/libclang.so.1'
-env['LLVM_DIR_PATH'] = tmpdir+'/libclang/usr/lib/llvm-11/'
+# Not needed anymore, part of pip install that carries the binary itself also
+# # libclang
+# subprocess.check_call(['wget', 'https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/libclang-11_manylinux2014_x86_64.tar.xz'], cwd=tmpdir)
+# subprocess.check_call(['mkdir', '-p', 'libclang'], cwd=tmpdir)
+# subprocess.check_call(['tar', 'xf', 'libclang-11_manylinux2014_x86_64.tar.xz', '-C', tmpdir+'/libclang/'], cwd=tmpdir)
+# env['LIBCLANG_PATH'] = tmpdir+'/libclang/usr/lib/llvm-11/lib/libclang.so.1'
+# env['LLVM_DIR_PATH'] = tmpdir+'/libclang/usr/lib/llvm-11/'
 
 # Build library and generate actual conf.py
 subprocess.run(["cmake -P ../ci.cmake"], cwd=cwd, shell=True, check=True, env=env)


### PR DESCRIPTION
Fixes RTD docs build - after 1ffd3fd73bb78519842078902a2042ea2e6758e4, things are in place to not require separate libclang anymore