### PR TITLE
Adds Pop OS support to install_dependencies.sh

### DIFF
--- a/docs/source/_static/install_dependencies.sh
+++ b/docs/source/_static/install_dependencies.sh
@@ -160,7 +160,7 @@ elif [ -f /etc/os-release ]; then
         fi
 
     # Check if the version is greater than 22.04 (Ubuntu) or 11 (Debian)
-    elif { [[ "$ID" == "debian" ]] && ! version_lte "$VERSION_ID" "11"; } || { [[ "$ID" == "ubuntu" ]] && ! version_lte "$VERSION_ID" "21.10"; }; then
+    elif { [[ "$ID" == "debian" ]] && ! version_lte "$VERSION_ID" "11"; } || { [[ "$ID" == "ubuntu" || "$ID" == "pop" ]] && ! version_lte "$VERSION_ID" "21.10"; }; then
         if $IS_ARM; then
             echo "Using post-22.04 package list for ARM"
             debian_arm_pkgs=("${debian_arm_pkgs[@]}")


### PR DESCRIPTION
[Pop OS](https://pop.system76.com/), which is Ubuntu based, is currently not supported by the install scripts.

This PR adds support for Pop OS to the install scripts.