### PR TITLE
Update install.rst

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,7 +16,7 @@ Follow the steps below to just install depthai api library dependencies for your
 
     .. code-block:: bash
 
-      bash -c "$(curl -fL https://docs.luxonis.com/install_dependencies.sh)"
+      curl -fL https://docs.luxonis.com/install_dependencies.sh | bash
 
     Please refer to :ref:`documentation below <macOS>` if any issues occur.
 


### PR DESCRIPTION
Change MacOS install command to 
`curl -fL https://docs.luxonis.com/install_dependencies.sh | bash`.

Reason: 
- Install command on linux is now more similar
- Error on MacOS due to:


>    Direct Execution (`bash script.sh`): When you run the script directly, any error triggers the trap, prints the custom message, and then exits. However, in a directly executed script, certain errors might be handled or bypassed differently due to explicit error handling within the script itself or because the script context allows it to continue past errors under certain conditions.

 >    Execution via bash -c: When you execute the script with `bash -c "$(curl -fL https://docs.luxonis.com/install_dependencies.sh)"`, the entire script is passed to Bash as a single command argument. In this context, the `ERR` trap's behavior is more immediate and global. Since the script is being treated as one continuous command, any trapped error will cause the entire command to exit, as the context is more sensitive to errors given its one-off execution nature.

The bash on mac has issues with line `["trixie/sid"]="13"` as it read "/" as a division. The error is harmless and can be ignored since the line is not accessed anyway.