### PR TITLE
Force numpy <2.0

### DIFF
--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -55,12 +55,12 @@ if thisPlatform == "aarch64":
         requireOpenCv = True
 
 if requireOpenCv:
-    DEPENDENCIES.append('numpy')
+    DEPENDENCIES.append('numpy<2.0')
     # 4.5.4.58 package is broken for python 3.9
     if sys.version_info[0] == 3 and sys.version_info[1] == 9:
         DEPENDENCIES.append('opencv-python!=4.5.4.58')
     else:
-        DEPENDENCIES.append('opencv-python')
+        DEPENDENCIES.append('opencv-python<5.0')
 
 
 


### PR DESCRIPTION
- Numpy >=2.0 currently breaks opencv. 