### PR TITLE
Fix Camera Type check in flashconfig

### DIFF
--- a/utilities/device_manager.py
+++ b/utilities/device_manager.py
@@ -948,7 +948,7 @@ class DeviceManager:
             pass
 
         try:
-            if self.isPoE:
+            if self.isPoE():
                 if self.values['staticBut']:
                     if check_ip(self.window, values['ip']) and check_ip(self.window, values['mask']) and check_ip(self.window, values['gateway'], req=False):
                         conf.setStaticIPv4(values['ip'], values['mask'], values['gateway'])


### PR DESCRIPTION
Bug: When trying to update the configuration of a USB camera, the program showed "Missing IP..." error message.

Solution: In the configuration update function, self.isPoE is a method, not an attribute, the if statement is wrong and was not checking the camera type, preventing any config update in case of USB camera.