### PR TITLE
Update manylinux to 2_28

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,9 +309,9 @@ jobs:
       # to be removed when upgrading the manylinux image
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
-      image: quay.io/pypa/manylinux2014_x86_64:latest
+      image: quay.io/pypa/manylinux_2_28_x86_64:latest
       env:
-        PLAT: manylinux2014_x86_64
+        PLAT: manylinux_2_28_x86_64
     steps:
       - name: Cache .hunter folder
         uses: actions/cache@v3
@@ -377,9 +377,9 @@ jobs:
       # to be removed when upgrading the manylinux image
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
-      image: quay.io/pypa/manylinux2014_aarch64:latest
+      image: quay.io/pypa/manylinux_2_28_aarch64:latest
       env:
-        PLAT: manylinux2014_aarch64
+        PLAT: manylinux_2_28_aarch64
       # Mount local hunter cache directory, instead of transfering to Github and back
       volumes:
         - /.hunter:/github/home/.hunter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,12 +136,8 @@ jobs:
     needs: build-docstrings
     strategy:
       matrix:
-        rpi-os: [rpi-buster, rpi-bullseye, rpi-bookworm]
+        rpi-os: [rpi-bullseye, rpi-bookworm]
     runs-on: ${{ matrix.rpi-os }}
-    env:
-      # workaround required for cache@v3, https://github.com/actions/cache/issues/1428
-      # to be removed when upgrading the manylinux image
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Print home directory
         run: echo Home directory inside container $HOME
@@ -304,10 +300,6 @@ jobs:
   build-linux-x86_64:
     needs: build-docstrings
     runs-on: ubuntu-latest
-    env:
-      # workaround required for cache@v3, https://github.com/actions/cache/issues/1428
-      # to be removed when upgrading the manylinux image
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64:latest
       env:
@@ -372,10 +364,6 @@ jobs:
   build-linux-arm64:
     needs: build-docstrings
     runs-on: [self-hosted, linux, ARM64]
-    env:
-      # workaround required for cache@v3, https://github.com/actions/cache/issues/1428
-      # to be removed when upgrading the manylinux image
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
       image: quay.io/pypa/manylinux_2_28_aarch64:latest
       env:


### PR DESCRIPTION
This PR introduces the following:
* Bumps the manylinux image to 2_28.
* Drops the support for RPI Buster, since it's EOL for some time now.


The main reason for the above is github actions essentially dropping support for runtimes that use GLIBC < 2.28.
https://github.com/actions/checkout/issues/1809



We're effectively dropping OS versions that are all EOL for some time.
The new minimum requirements for the popular Linux OSes are now:
>Built wheels are also expected to be compatible with other distros using glibc 2.28 or later, including:

> Debian 10+
> Ubuntu 18.10+
> Fedora 29+
> CentOS/RHEL 8+

(from https://github.com/pypa/manylinux)

