### PR TITLE
Add venv check for conda/mamba

### DIFF
--- a/examples/install_requirements.py
+++ b/examples/install_requirements.py
@@ -68,7 +68,13 @@ if requireOpenCv:
 ARTIFACTORY_URL = 'https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local'
 
 # Check if in virtual environment
-in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
+in_venv = any([
+    "VIRTUAL_ENV" in os.environ,      # Virtualenv
+    "PIPENV_ACTIVE" in os.environ,    # Pipenv
+    "CONDA_PREFIX" in os.environ,     # Conda/Mamba
+    getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix  # Standard venv detection
+])
+
 pip_call = [sys.executable, "-m", "pip"]
 pip_installed = True
 pip_install = pip_call + ["install", "-U"]


### PR DESCRIPTION
Sometimes when using conda/mamba, the installation of depthai is done using the `--user` flag because venv is not detected properly. This causes depthai version override over all present environments. Added this check to ensure that does not happen.