### PR TITLE
Fix device manager when streaming OV9782 sensor

### DIFF
--- a/utilities/device_manager.py
+++ b/utilities/device_manager.py
@@ -312,16 +312,13 @@ def connectAndStartStreaming(dev):
                     break
         else:
             camRgb = pipeline.create(dai.node.ColorCamera)
-            camRgb.setIspScale(1,3)
-            firstSensor = d.getConnectedCameraFeatures()[0]
-            camRgb.setPreviewSize(firstSensor.width // 3, firstSensor.height // 3)
-            camRgb.setColorOrder(camRgb.Properties.ColorOrder.RGB)
+            camRgb.setIspScale(1,2)
 
             xout = pipeline.create(dai.node.XLinkOut)
             xout.input.setQueueSize(2)
             xout.input.setBlocking(False)
             xout.setStreamName("color")
-            camRgb.preview.link(xout.input)
+            camRgb.isp.link(xout.input)
 
             # Start pipeline
             d.startPipeline(pipeline)
@@ -343,7 +340,7 @@ def connectAndStartStreaming(dev):
             while not d.isClosed():
                 frame = d.getOutputQueue('color').get()
                 with io.BytesIO() as output:
-                    rgb = frame.getFrame()
+                    rgb = frame.getCvFrame()[:,:,::-1]
                     image = Image.fromarray(rgb, "RGB")
                     image.save(output, format="GIF")
                     contents = output.getvalue()


### PR DESCRIPTION
**Before**:
![image](https://github.com/user-attachments/assets/e60daf03-8fa5-4f20-95fa-cef7475c6753)

For some reason, OV9782 doesn't like being ISP downscaled (1,3), and produces visual artifact. If we downscale it by 1/2 then it works as expected.

**After:**
![image](https://github.com/user-attachments/assets/397b32b3-7c5c-4bef-961f-e1d8f6fb4ec1)
