### PR TITLE
ObjectTracker: expose tracking paramters; add force remove functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ pybind11_add_module(${TARGET_NAME}
     src/pipeline/datatype/PointCloudConfigBindings.cpp
     src/pipeline/datatype/PointCloudDataBindings.cpp
     src/pipeline/datatype/ImageAlignConfigBindings.cpp
+    src/pipeline/datatype/ObjectTrackerConfigBindings.cpp
 )
 
 if(WIN32)

--- a/src/DatatypeBindings.cpp
+++ b/src/DatatypeBindings.cpp
@@ -28,6 +28,7 @@ void bind_tracklets(pybind11::module& m, void* pCallstack);
 void bind_pointcloudconfig(pybind11::module& m, void* pCallstack);
 void bind_pointclouddata(pybind11::module& m, void* pCallstack);
 void bind_imagealignconfig(pybind11::module& m, void* pCallstack);
+void bind_objecttrackerconfig(pybind11::module& m, void* pCallstack);
 
 void DatatypeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
      // Bind common datatypebindings
@@ -59,6 +60,7 @@ void DatatypeBindings::addToCallstack(std::deque<StackFunction>& callstack) {
     callstack.push_front(bind_pointcloudconfig);
     callstack.push_front(bind_pointclouddata);
     callstack.push_front(bind_imagealignconfig);
+    callstack.push_front(bind_objecttrackerconfig);
 }
 
 void DatatypeBindings::bind(pybind11::module& m, void* pCallstack){

--- a/src/pipeline/datatype/ObjectTrackerConfigBindings.cpp
+++ b/src/pipeline/datatype/ObjectTrackerConfigBindings.cpp
@@ -42,7 +42,7 @@ void bind_objecttrackerconfig(pybind11::module& m, void* pCallstack){
     config
         .def(py::init<>())
         .def(py::init<std::shared_ptr<RawObjectTrackerConfig>>())
-        
+
         .def("set", &ObjectTrackerConfig::set, py::arg("config"), DOC(dai, ObjectTrackerConfig, set))
         .def("get", &ObjectTrackerConfig::get, DOC(dai, ObjectTrackerConfig, get))
         .def("forceRemoveID", &ObjectTrackerConfig::forceRemoveID, DOC(dai, ObjectTrackerConfig, forceRemoveID))

--- a/src/pipeline/datatype/ObjectTrackerConfigBindings.cpp
+++ b/src/pipeline/datatype/ObjectTrackerConfigBindings.cpp
@@ -1,0 +1,54 @@
+#include "DatatypeBindings.hpp"
+#include "pipeline/CommonBindings.hpp"
+#include <unordered_map>
+#include <memory>
+
+// depthai
+#include "depthai/pipeline/datatype/ObjectTrackerConfig.hpp"
+
+//pybind
+#include <pybind11/chrono.h>
+#include <pybind11/numpy.h>
+
+// #include "spdlog/spdlog.h"
+
+void bind_objecttrackerconfig(pybind11::module& m, void* pCallstack){
+
+    using namespace dai;
+
+    py::class_<RawObjectTrackerConfig, RawBuffer, std::shared_ptr<RawObjectTrackerConfig>> rawConfig(m, "RawObjectTrackerConfig", DOC(dai, RawObjectTrackerConfig));
+    py::class_<ObjectTrackerConfig, Buffer, std::shared_ptr<ObjectTrackerConfig>> config(m, "ObjectTrackerConfig", DOC(dai, ObjectTrackerConfig));
+
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    // Call the rest of the type defines, then perform the actual bindings
+    Callstack* callstack = (Callstack*) pCallstack;
+    auto cb = callstack->top();
+    callstack->pop();
+    cb(m, pCallstack);
+    // Actual bindings
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+
+    // Metadata / raw
+    rawConfig
+        .def(py::init<>())
+        .def_readwrite("trackletIdsToRemove", &RawObjectTrackerConfig::trackletIdsToRemove, DOC(dai, RawObjectTrackerConfig, trackletIdsToRemove))
+        ;
+
+    // Message
+    config
+        .def(py::init<>())
+        .def(py::init<std::shared_ptr<RawObjectTrackerConfig>>())
+        
+        .def("set", &ObjectTrackerConfig::set, py::arg("config"), DOC(dai, ObjectTrackerConfig, set))
+        .def("get", &ObjectTrackerConfig::get, DOC(dai, ObjectTrackerConfig, get))
+        .def("forceRemoveID", &ObjectTrackerConfig::forceRemoveID, DOC(dai, ObjectTrackerConfig, forceRemoveID))
+        .def("forceRemoveIDs", &ObjectTrackerConfig::forceRemoveIDs, DOC(dai, ObjectTrackerConfig, forceRemoveIDs))
+        ;
+
+    // add aliases
+
+}

--- a/src/pipeline/node/ObjectTrackerBindings.cpp
+++ b/src/pipeline/node/ObjectTrackerBindings.cpp
@@ -48,6 +48,9 @@ void bind_objecttracker(pybind11::module& m, void* pCallstack){
         .def_readwrite("detectionLabelsToTrack", &ObjectTrackerProperties::detectionLabelsToTrack, DOC(dai, ObjectTrackerProperties, detectionLabelsToTrack))
         .def_readwrite("trackerType", &ObjectTrackerProperties::trackerType, DOC(dai, ObjectTrackerProperties, trackerType))
         .def_readwrite("trackerIdAssignmentPolicy", &ObjectTrackerProperties::trackerIdAssignmentPolicy, DOC(dai, ObjectTrackerProperties, trackerIdAssignmentPolicy))
+        .def_readwrite("trackingPerClass", &ObjectTrackerProperties::trackingPerClass, DOC(dai, ObjectTrackerProperties, trackingPerClass))
+        .def_readwrite("occlusionRatioThreshold", &ObjectTrackerProperties::occlusionRatioThreshold, DOC(dai, ObjectTrackerProperties, occlusionRatioThreshold))
+        .def_readwrite("trackingPerClass", &ObjectTrackerProperties::trackingPerClass, DOC(dai, ObjectTrackerProperties, trackingPerClass))
         ;
 
     // Node
@@ -66,6 +69,9 @@ void bind_objecttracker(pybind11::module& m, void* pCallstack){
         .def("setTrackerType", &ObjectTracker::setTrackerType, py::arg("type"), DOC(dai, node, ObjectTracker, setTrackerType))
         .def("setTrackerIdAssignmentPolicy", &ObjectTracker::setTrackerIdAssignmentPolicy, py::arg("type"), DOC(dai, node, ObjectTracker, setTrackerIdAssignmentPolicy))
         .def("setTrackingPerClass", &ObjectTracker::setTrackingPerClass, py::arg("trackingPerClass"), DOC(dai, node, ObjectTracker, setTrackingPerClass))
+        .def("setOcclusionRatioThreshold", &ObjectTracker::setOcclusionRatioThreshold, py::arg("occlusionRatioThreshold"), DOC(dai, node, ObjectTracker, setOcclusionRatioThreshold))
+        .def("setTrackletMaxLifespan", &ObjectTracker::setTrackletMaxLifespan, py::arg("lifespan"), DOC(dai, node, ObjectTracker, setTrackletMaxLifespan))
+        .def("setTrackletBirthThreshold", &ObjectTracker::setTrackletBirthThreshold, py::arg("threshold"), DOC(dai, node, ObjectTracker, setTrackletBirthThreshold))
         ;
     daiNodeModule.attr("ObjectTracker").attr("Properties") = objectTrackerProperties;
 

--- a/src/pipeline/node/ObjectTrackerBindings.cpp
+++ b/src/pipeline/node/ObjectTrackerBindings.cpp
@@ -50,7 +50,8 @@ void bind_objecttracker(pybind11::module& m, void* pCallstack){
         .def_readwrite("trackerIdAssignmentPolicy", &ObjectTrackerProperties::trackerIdAssignmentPolicy, DOC(dai, ObjectTrackerProperties, trackerIdAssignmentPolicy))
         .def_readwrite("trackingPerClass", &ObjectTrackerProperties::trackingPerClass, DOC(dai, ObjectTrackerProperties, trackingPerClass))
         .def_readwrite("occlusionRatioThreshold", &ObjectTrackerProperties::occlusionRatioThreshold, DOC(dai, ObjectTrackerProperties, occlusionRatioThreshold))
-        .def_readwrite("trackingPerClass", &ObjectTrackerProperties::trackingPerClass, DOC(dai, ObjectTrackerProperties, trackingPerClass))
+        .def_readwrite("trackletMaxLifespan", &ObjectTrackerProperties::trackletMaxLifespan, DOC(dai, ObjectTrackerProperties, trackletMaxLifespan))
+        .def_readwrite("trackletBirthThreshold", &ObjectTrackerProperties::trackletBirthThreshold, DOC(dai, ObjectTrackerProperties, trackletBirthThreshold))
         ;
 
     // Node

--- a/src/pipeline/node/ObjectTrackerBindings.cpp
+++ b/src/pipeline/node/ObjectTrackerBindings.cpp
@@ -58,6 +58,7 @@ void bind_objecttracker(pybind11::module& m, void* pCallstack){
         .def_readonly("inputTrackerFrame", &ObjectTracker::inputTrackerFrame, DOC(dai, node, ObjectTracker, inputTrackerFrame))
         .def_readonly("inputDetectionFrame", &ObjectTracker::inputDetectionFrame, DOC(dai, node, ObjectTracker, inputDetectionFrame))
         .def_readonly("inputDetections", &ObjectTracker::inputDetections, DOC(dai, node, ObjectTracker, inputDetections))
+        .def_readonly("inputConfig", &ObjectTracker::inputConfig, DOC(dai, node, ObjectTracker, inputConfig))
         .def_readonly("out", &ObjectTracker::out, DOC(dai, node, ObjectTracker, out))
         .def_readonly("passthroughTrackerFrame", &ObjectTracker::passthroughTrackerFrame, DOC(dai, node, ObjectTracker, passthroughTrackerFrame))
         .def_readonly("passthroughDetectionFrame", &ObjectTracker::passthroughDetectionFrame, DOC(dai, node, ObjectTracker, passthroughDetectionFrame))


### PR DESCRIPTION
Updated object_tracker.py to reflect new functionality and API usage:

```
objectTracker.setOcclusionRatioThreshold(0.4)
objectTracker.setTrackletMaxLifespan(120)
objectTracker.setTrackletBirthThreshold(3)
```

```
config = dai.ObjectTrackerConfig()
config.forceRemoveID(idToRemove)
trackerConfigQueue.send(config)
```

## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable