### PR TITLE
RVC2 crashdump improvements, bindings for

### DIFF
--- a/src/DeviceBindings.cpp
+++ b/src/DeviceBindings.cpp
@@ -485,6 +485,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack){
         .def("getSystemInformationLoggingRate", [](DeviceBase& d) { py::gil_scoped_release release; return d.getSystemInformationLoggingRate(); }, DOC(dai, DeviceBase, getSystemInformationLoggingRate))
         .def("getCrashDump", [](DeviceBase& d, bool clearCrashDump) { py::gil_scoped_release release; return d.getCrashDump(clearCrashDump); }, py::arg("clearCrashDump") = true, DOC(dai, DeviceBase, getCrashDump))
         .def("hasCrashDump", [](DeviceBase& d) { py::gil_scoped_release release; return d.hasCrashDump(); }, DOC(dai, DeviceBase, hasCrashDump))
+        .def("getState", [](DeviceBase& d) { py::gil_scoped_release release; return d.getState(); }, DOC(dai, DeviceBase, getState))
         .def("getConnectedCameras", [](DeviceBase& d) { py::gil_scoped_release release; return d.getConnectedCameras(); }, DOC(dai, DeviceBase, getConnectedCameras))
         .def("getConnectionInterfaces", [](DeviceBase& d) { py::gil_scoped_release release; return d.getConnectionInterfaces(); }, DOC(dai, DeviceBase, getConnectionInterfaces))
         .def("getConnectedCameraFeatures", [](DeviceBase& d) { py::gil_scoped_release release; return d.getConnectedCameraFeatures(); }, DOC(dai, DeviceBase, getConnectedCameraFeatures))

--- a/src/pipeline/node/MessageDemuxBindings.cpp
+++ b/src/pipeline/node/MessageDemuxBindings.cpp
@@ -30,13 +30,20 @@ void bind_messagedemux(pybind11::module &m, void *pCallstack) {
   ///////////////////////////////////////////////////////////////////////
 
   // Properties
+  messageDemuxProperties
+      .def_readwrite("processor", &MessageDemuxProperties::processor,
+                     DOC(dai, MessageDemuxProperties, processor));
 
   // Node
   messageDemux
       .def_readonly("outputs", &MessageDemux::outputs,
                     DOC(dai, node, MessageDemux, outputs))
       .def_readonly("input", &MessageDemux::input,
-                    DOC(dai, node, MessageDemux, input));
+                    DOC(dai, node, MessageDemux, input))
+      .def("setProcessor", &MessageDemux::setProcessor,
+           DOC(dai, node, MessageDemux, setProcessor))
+      .def("getProcessor", &MessageDemux::getProcessor,
+           DOC(dai, node, MessageDemux, getProcessor));
   daiNodeModule.attr("MessageDemux").attr("Properties") =
       messageDemuxProperties;
 }

--- a/src/pipeline/node/SyncBindings.cpp
+++ b/src/pipeline/node/SyncBindings.cpp
@@ -32,6 +32,7 @@ void bind_sync(pybind11::module& m, void* pCallstack){
     syncProperties
         .def_readwrite("syncThresholdNs", &SyncProperties::syncThresholdNs)
         .def_readwrite("syncAttempts", &SyncProperties::syncAttempts)
+        .def_readwrite("processor", &SyncProperties::processor, DOC(dai, SyncProperties, processor))
         ;
 
     // Node
@@ -40,6 +41,8 @@ void bind_sync(pybind11::module& m, void* pCallstack){
         .def_readonly("inputs", &Sync::inputs, DOC(dai, node, Sync, inputs))
         .def("setSyncThreshold", &Sync::setSyncThreshold, py::arg("syncThreshold"), DOC(dai, node, Sync, setSyncThreshold))
         .def("setSyncAttempts", &Sync::setSyncAttempts, py::arg("maxDataSize"), DOC(dai, node, Sync, setSyncAttempts))
+        .def("setProcessor", &Sync::setProcessor, DOC(dai, node, Sync, setProcessor))
+        .def("getProcessor", &Sync::getProcessor, DOC(dai, node, Sync, getProcessor))
         .def("getSyncThreshold", &Sync::getSyncThreshold, DOC(dai, node, Sync, getSyncThreshold))
         .def("getSyncAttempts", &Sync::getSyncAttempts, DOC(dai, node, Sync, getSyncAttempts))
         ;


### PR DESCRIPTION
Device getState, Sync + MessageDemux get/setProcessor

## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable